### PR TITLE
feat/router-context-setting: Router 및 Protected Router 설정

### DIFF
--- a/client/public/mocks/User.json
+++ b/client/public/mocks/User.json
@@ -1,0 +1,5 @@
+{
+  "id": "1",
+  "username": "Lukaid-dev",
+  "avatar_url": "https://avatars.githubusercontent.com/u/97015501?v=4"
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
   return (
     <>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider value={null}>
+        <AuthProvider>
           <Outlet />
         </AuthProvider>
       </QueryClientProvider>

--- a/client/src/apis/Auth.ts
+++ b/client/src/apis/Auth.ts
@@ -6,6 +6,8 @@ const config = {
 };
 
 export async function login(): Promise<UserType> {
-  const response = await axios.post(`${config.baseUrl}/auth/login`, {});
+  // const response = await axios.post(`${config.baseUrl}/auth/login`, {});
+  // mock data from /mocks/User.json
+  const response = await axios.get('/mocks/User.json');
   return response.data;
 }

--- a/client/src/apis/Auth.ts
+++ b/client/src/apis/Auth.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { UserType } from '../types/UserType';
+
+const config = {
+  baseUrl: import.meta.env.VITE_API_BASE_URL as string,
+};
+
+export async function login(): Promise<UserType> {
+  const response = await axios.post(`${config.baseUrl}/auth/login`, {});
+  return response.data;
+}

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,25 +1,49 @@
+import { useNavigate } from 'react-router-dom';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { login } from '../apis/Auth';
 import { UserType } from '../types/UserType';
 
 interface AuthContextType {
   user: UserType | null;
+  onLogin: () => Promise<void>;
+  onLogout: () => void;
 }
 
-const AuthContext = createContext<AuthContextType>({ user: null });
+// TODO: 서버의 세션 확인 api가 개발 되면 그때 localStorage로직을 변경
+
+const AuthContext = createContext<AuthContextType>({} as AuthContextType);
 
 export const AuthProvider = ({ children }: { children: JSX.Element }) => {
+  const navigate = useNavigate();
+
+  // 새로고침하면 여기서 다시 user가 null이 되어, 로그인이 풀린다...
   const [user, setUser] = useState<UserType | null>(null);
 
+  const onLogin = async () => {
+    const res = await login();
+    setUser(res);
+    // 이를 해결하기 위해 로컬스토리지에 저장한다. 추후에 서버에서 세션을 관리하면 만료시간에 관한 로직도 추가해야 한다.
+    localStorage.setItem('user', JSON.stringify(res));
+    navigate('/lobby');
+  };
+
+  const onLogout = () => {
+    setUser(null);
+    localStorage.removeItem('user');
+  };
+
   useEffect(() => {
-    console.log('AuthProvider');
-    login().then((res) => {
-      setUser(res);
-    });
+    // 새로고침시 로컬스토리지에서 user를 가져온다.
+    if (localStorage.getItem('user')) {
+      // 로컬스토리지에 user가 있으면 setUser한다.
+      setUser(JSON.parse(localStorage.getItem('user') as string));
+    }
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ user, onLogin, onLogout }}>
+      {children}
+    </AuthContext.Provider>
   );
 };
 

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,17 +1,26 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { login } from '../apis/Auth';
+import { UserType } from '../types/UserType';
 
-const AuthContext = createContext({});
+interface AuthContextType {
+  user: UserType | null;
+}
 
-export const AuthProvider = ({
-  children,
-  value,
-}: {
-  children: JSX.Element;
-  value: unknown;
-}) => {
+const AuthContext = createContext<AuthContextType>({ user: null });
+
+export const AuthProvider = ({ children }: { children: JSX.Element }) => {
+  const [user, setUser] = useState<UserType | null>(null);
+
+  useEffect(() => {
+    console.log('AuthProvider');
+    login().then((res) => {
+      setUser(res);
+    });
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ value }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>
   );
 };
 
-export const useAuth = () => useContext(AuthContext);
+export const useAuthContext = () => useContext(AuthContext);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,16 +1,16 @@
-import { useState } from 'react';
+import { useAuthContext } from '../contexts/AuthContext';
 
 export default function Home() {
-  const [count, setCount] = useState(0);
+  const { onLogin } = useAuthContext();
   return (
     <>
       <h1 className="bg-red-50 text-2xl font-bold">BOJ Rooms</h1>
-      <h2>{count}</h2>
       <button
+        className="border-2 border-black p-2"
         onClick={() => {
-          setCount(count + 1);
+          onLogin();
         }}>
-        test
+        Login
       </button>
     </>
   );

--- a/client/src/pages/Lobby.tsx
+++ b/client/src/pages/Lobby.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
-export default function Home() {
+export default function Lobby() {
   const [count, setCount] = useState(0);
   return (
     <>
-      <h1 className="bg-red-50 text-2xl font-bold">BOJ Rooms</h1>
+      <h1 className="bg-red-50 text-2xl font-bold">Lobby</h1>
       <h2>{count}</h2>
       <button
         onClick={() => {

--- a/client/src/pages/Lobby.tsx
+++ b/client/src/pages/Lobby.tsx
@@ -1,17 +1,21 @@
-import { useState } from 'react';
+import { useAuthContext } from '../contexts/AuthContext';
+import { Link } from 'react-router-dom';
 
 export default function Lobby() {
-  const [count, setCount] = useState(0);
+  const { user, onLogout } = useAuthContext();
+
   return (
     <>
       <h1 className="bg-red-50 text-2xl font-bold">Lobby</h1>
-      <h2>{count}</h2>
+      <h2>{user?.username}</h2>
       <button
+        className="border-2 border-black p-2"
         onClick={() => {
-          setCount(count + 1);
+          onLogout();
         }}>
-        test
+        Logout
       </button>
+      <Link to="/room/1">Room</Link>
     </>
   );
 }

--- a/client/src/pages/ProtectedRoute.tsx
+++ b/client/src/pages/ProtectedRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthContext } from '../contexts/AuthContext';
+
+export default function ProtectedRoute({
+  children,
+}: {
+  children: JSX.Element;
+}) {
+  const { user } = useAuthContext();
+  if (!user) {
+    console.log('ProtectedRoute: user is null');
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}

--- a/client/src/pages/ProtectedRoute.tsx
+++ b/client/src/pages/ProtectedRoute.tsx
@@ -1,15 +1,13 @@
 import { Navigate } from 'react-router-dom';
-import { useAuthContext } from '../contexts/AuthContext';
 
 export default function ProtectedRoute({
   children,
 }: {
   children: JSX.Element;
 }) {
-  const { user } = useAuthContext();
-  if (!user) {
-    console.log('ProtectedRoute: user is null');
+  if (!localStorage.getItem('user')) {
     return <Navigate to="/" replace />;
+  } else {
   }
 
   return children;

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -1,0 +1,7 @@
+export default function Room() {
+  return (
+    <div>
+      <h1>Room</h1>
+    </div>
+  );
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -15,21 +15,24 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
+        path: '/',
         element: <Home />,
       },
       {
-        path: 'lobby',
+        path: '/lobby',
         element: (
           <ProtectedRoute>
             <Lobby />
           </ProtectedRoute>
         ),
-        children: [
-          {
-            path: 'room/:roomId',
-            element: <Room />,
-          },
-        ],
+      },
+      {
+        path: '/room/:roomId',
+        element: (
+          <ProtectedRoute>
+            <Room />
+          </ProtectedRoute>
+        ),
       },
     ],
   },

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -1,8 +1,11 @@
 import { createBrowserRouter } from 'react-router-dom';
+import ProtectedRoute from './pages/ProtectedRoute.tsx';
 
 import App from './App.tsx';
 import Home from './pages/Home.tsx';
 import NotFound from './pages/NotFound.tsx';
+import Lobby from './pages/Lobby.tsx';
+import Room from './pages/Room.tsx';
 
 export const router = createBrowserRouter([
   {
@@ -15,8 +18,18 @@ export const router = createBrowserRouter([
         element: <Home />,
       },
       {
-        path: 'home',
-        element: <Home />,
+        path: 'lobby',
+        element: (
+          <ProtectedRoute>
+            <Lobby />
+          </ProtectedRoute>
+        ),
+        children: [
+          {
+            path: 'room/:roomId',
+            element: <Room />,
+          },
+        ],
       },
     ],
   },

--- a/client/src/types/UserType.ts
+++ b/client/src/types/UserType.ts
@@ -1,0 +1,5 @@
+export interface UserType {
+  id: string;
+  username: string;
+  avatar_url: string;
+}


### PR DESCRIPTION
## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?


## Description

router를 수정하고, 로그인을 하지 않으면 다음 페이지로 넘어갈 수 없도록 Protected Router를 설정했습니다.

close #38 

## Changes Made

- client/src/App.tsx
  - AuthProvider에 value를 넘겨줄 필요가 없도록 수정
- client/src/apis/Auth.ts
  - 임시로 login api작성
- client/src/contexts/AuthContext.tsx
  - context자체에서 api를 요청하여 유저 정보를 받아오도록 하였고, 추후에 로그인이 되었을 때 useEffect를 다시 부르도록 의존성 배열을 추가하거나, 아예 다른 방향으로 수정하는 것도 생각중입니다. (의견 제시해 주십셔)
- client/src/pages/Home.tsx
  - 임시 home count로 리렌더 되어도 그 윗단의 Provider에서 useEffect가 다시 안불리는거 확인용으로 달아둠
- client/src/pages/Lobby.tsx
  - 임시 로비
- client/src/pages/ProtectedRoute.tsx
  - 로그인 가드 역할. 로그인을 하지 않아 user정보가 없을 시 home으로 redirect
- client/src/pages/Room.tsx
  - 임시 방
- client/src/routes.tsx
  - 수정된 router. ProtectedRoute된 컴포넌트 하위의 children은 모두 보호가 되는 것으로 확인함. (확실하지 않음 더 알아봐야 함)
- client/src/types/UserType.ts
  - 오늘 논의한 내용을 바탕으로 User 데이터 정의

## Extra Comments

아직 여러가지로 명확하지 않은 상황에서 작성한지라 오류가 많을 것 같습니다. 꼼꼼히 리뷰해주시고 수정사항 지적해주시면 감사하겠습니다.

## Demo

https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/97015501/7558f4ff-221a-4436-8255-5203359e1b18


