### PR TITLE
Feat/room setting/UI: 방 설정 창 UI

### DIFF
--- a/client/src/pages/RoomSetting.tsx
+++ b/client/src/pages/RoomSetting.tsx
@@ -11,6 +11,9 @@ export default function RoomSetting() {
     setProblemList([...problemList, problem]);
     setProblem('');
   };
+  const deleteProblem = (deleteIndex: number) => {
+    setProblemList(problemList.filter((_, index) => index !== deleteIndex));
+  };
 
   return (
     <>
@@ -35,7 +38,13 @@ export default function RoomSetting() {
               <div className="w-[150px] rounded-lg font-semibold">
                 {problem}
               </div>
-              <button className="px-2 py-1">❌</button>
+              <button
+                className="px-2 py-1"
+                onClick={() => {
+                  deleteProblem(index);
+                }}>
+                ❌
+              </button>
             </div>
           ))}
         </div>

--- a/client/src/pages/RoomSetting.tsx
+++ b/client/src/pages/RoomSetting.tsx
@@ -1,0 +1,63 @@
+export default function RoomSetting() {
+  return (
+    <>
+      <div className="h-[450px] w-[350px] border-2">
+        <div>번호로 출제</div>
+        <form>
+          <input className="rounded-lg px-2 py-1" />
+          <button>등록</button>
+        </form>
+        <div className="h-[250px] w-[250px] border-2"></div>
+        <div>
+          <select>
+            <option value="15분">15분</option>
+            <option value="15분">30분</option>
+            <option value="15분">45분</option>
+            <option value="15분">60분</option>
+            <option value="15분">90분</option>
+            <option value="15분">120분</option>
+            <option value="15분">무제한</option>
+          </select>
+          <button>설정 완료</button>
+        </div>
+      </div>
+
+      <div className="h-[450px] w-[350px] border-2">
+        <div>랜덤 출제</div>
+        <form>
+          <select>
+            <option value="브론즈">브론즈</option>
+            <option value="실버">실버</option>
+            <option value="골드">골드</option>
+            <option value="플레티넘">플레티넘</option>
+            <option value="다이아">다이아</option>
+          </select>
+          <select>
+            <option value="bfs,dfs">bfs,dfs</option>
+          </select>
+          <select>
+            <option value="1개">1개</option>
+            <option value="2개">2개</option>
+            <option value="3개">3개</option>
+            <option value="4개">4개</option>
+            <option value="5개">5개</option>
+          </select>
+          <button>등록</button>
+        </form>
+        <div className="h-[250px] w-[250px] border-2"></div>
+        <div>
+          <select>
+            <option value="15분">15분</option>
+            <option value="30분">30분</option>
+            <option value="45분">45분</option>
+            <option value="60분">60분</option>
+            <option value="90분">90분</option>
+            <option value="120분">120분</option>
+            <option value="무제한">무제한</option>
+          </select>
+          <button>설정 완료</button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/RoomSetting.tsx
+++ b/client/src/pages/RoomSetting.tsx
@@ -1,15 +1,44 @@
+import { useState } from 'react';
+
 export default function RoomSetting() {
+  const [problem, setProblem] = useState('');
+  const [problemList, setProblemList] = useState<string[]>([]);
+  const onChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setProblem(event.target.value);
+  };
+  const registerProblem = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setProblemList([...problemList, problem]);
+    setProblem('');
+  };
+
   return (
     <>
       <div className="flex h-[430px] w-[330px] flex-col items-center bg-gray-400">
         <div className="mb-2 mt-4 text-lg font-semibold">번호로 출제</div>
-        <form className="m-2 flex w-[250px] justify-between">
-          <input className="rounded-lg bg-gray-200 px-2 py-1" />
+        <form
+          className="m-2 flex w-[250px] justify-between"
+          onSubmit={registerProblem}>
+          <input
+            className="rounded-lg bg-gray-200 px-2 py-1"
+            placeholder="문제를 입력하시오"
+            value={problem}
+            onChange={onChangeInput}
+          />
           <button className="rounded-lg bg-gray-800 px-3 text-sm text-white hover:bg-gray-600">
             등록
           </button>
         </form>
-        <div className="m-2 h-[250px] w-[250px] rounded-lg border-2"></div>
+        <div className="m-2 flex h-[250px] w-[250px] flex-col items-center rounded-lg border-2 p-4">
+          {problemList.map((problem, index) => (
+            <div className="flex w-full justify-between" key={index}>
+              <div className="w-[150px] rounded-lg font-semibold">
+                {problem}
+              </div>
+              <button className="px-2 py-1">❌</button>
+            </div>
+          ))}
+        </div>
         <div className="m-2 flex w-[250px] justify-between">
           <select className="rounded-lg bg-gray-200 px-2 py-1">
             <option value="15분">15분</option>
@@ -25,6 +54,8 @@ export default function RoomSetting() {
           </button>
         </div>
       </div>
+
+      <div className="h-[10px] w-[10px]"></div>
 
       <div className="flex h-[430px] w-[330px] flex-col items-center bg-gray-400">
         <div className="mb-2 mt-4 text-lg font-semibold">랜덤 출제</div>

--- a/client/src/pages/RoomSetting.tsx
+++ b/client/src/pages/RoomSetting.tsx
@@ -1,15 +1,17 @@
 export default function RoomSetting() {
   return (
     <>
-      <div className="h-[450px] w-[350px] border-2">
-        <div>번호로 출제</div>
-        <form>
-          <input className="rounded-lg px-2 py-1" />
-          <button>등록</button>
+      <div className="flex h-[430px] w-[330px] flex-col items-center bg-gray-400">
+        <div className="mb-2 mt-4 text-lg font-semibold">번호로 출제</div>
+        <form className="m-2 flex w-[250px] justify-between">
+          <input className="rounded-lg bg-gray-200 px-2 py-1" />
+          <button className="rounded-lg bg-gray-800 px-3 text-sm text-white hover:bg-gray-600">
+            등록
+          </button>
         </form>
-        <div className="h-[250px] w-[250px] border-2"></div>
-        <div>
-          <select>
+        <div className="m-2 h-[250px] w-[250px] rounded-lg border-2"></div>
+        <div className="m-2 flex w-[250px] justify-between">
+          <select className="rounded-lg bg-gray-200 px-2 py-1">
             <option value="15분">15분</option>
             <option value="15분">30분</option>
             <option value="15분">45분</option>
@@ -18,44 +20,51 @@ export default function RoomSetting() {
             <option value="15분">120분</option>
             <option value="15분">무제한</option>
           </select>
-          <button>설정 완료</button>
+          <button className="rounded-lg bg-gray-800 px-5 py-1 text-sm text-white hover:bg-gray-600">
+            설정 완료
+          </button>
         </div>
       </div>
 
-      <div className="h-[450px] w-[350px] border-2">
-        <div>랜덤 출제</div>
-        <form>
-          <select>
-            <option value="브론즈">브론즈</option>
-            <option value="실버">실버</option>
-            <option value="골드">골드</option>
-            <option value="플레티넘">플레티넘</option>
-            <option value="다이아">다이아</option>
+      <div className="flex h-[430px] w-[330px] flex-col items-center bg-gray-400">
+        <div className="mb-2 mt-4 text-lg font-semibold">랜덤 출제</div>
+        <form className="m-2 flex w-[250px] justify-between">
+          <select className="rounded-lg bg-gray-200 px-1">
+            <option value="B5">B5</option>
+            <option value="S5">S5</option>
+            <option value="G5">G5</option>
+            <option value="P5">P5</option>
+            <option value="D5">D5</option>
+            <option value="R5">R5</option>
           </select>
-          <select>
+          <select className="rounded-lg bg-gray-200 px-1">
             <option value="bfs,dfs">bfs,dfs</option>
           </select>
-          <select>
+          <select className="rounded-lg bg-gray-200 px-1">
             <option value="1개">1개</option>
             <option value="2개">2개</option>
             <option value="3개">3개</option>
             <option value="4개">4개</option>
             <option value="5개">5개</option>
           </select>
-          <button>등록</button>
+          <button className="rounded-lg bg-gray-800 px-3 py-1 text-sm text-white hover:bg-gray-600">
+            등록
+          </button>
         </form>
-        <div className="h-[250px] w-[250px] border-2"></div>
-        <div>
-          <select>
+        <div className="m-2 h-[250px] w-[250px] rounded-lg border-2"></div>
+        <div className="m-2 flex w-[250px] justify-between">
+          <select className="rounded-lg bg-gray-200 px-2 py-1">
             <option value="15분">15분</option>
-            <option value="30분">30분</option>
-            <option value="45분">45분</option>
-            <option value="60분">60분</option>
-            <option value="90분">90분</option>
-            <option value="120분">120분</option>
-            <option value="무제한">무제한</option>
+            <option value="15분">30분</option>
+            <option value="15분">45분</option>
+            <option value="15분">60분</option>
+            <option value="15분">90분</option>
+            <option value="15분">120분</option>
+            <option value="15분">무제한</option>
           </select>
-          <button>설정 완료</button>
+          <button className="rounded-lg bg-gray-800 px-5 py-1 text-sm text-white hover:bg-gray-600">
+            설정 완료
+          </button>
         </div>
       </div>
     </>

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -6,6 +6,7 @@ import Home from './pages/Home.tsx';
 import NotFound from './pages/NotFound.tsx';
 import Lobby from './pages/Lobby.tsx';
 import Room from './pages/Room.tsx';
+import RoomSetting from './pages/RoomSetting.tsx';
 
 export const router = createBrowserRouter([
   {
@@ -33,6 +34,10 @@ export const router = createBrowserRouter([
             <Room />
           </ProtectedRoute>
         ),
+      },
+      {
+        path: '/roomsetting',
+        element: <RoomSetting />,
       },
     ],
   },


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

방 옵션을 설정하는 창의 UI를 구성하였습니다.
방 옵션 설정 창은 직접 문제 출제와 랜덤 문제 출제 설정 창이 있습니다.
일단 /roomsetting 페이지에 두 가지 창 UI를 구현해 놓았습니다.

close #44 
close #48 

<!-- List core changes that were made in this pull request -->

## Changes Made

- client/src/pages/RoomSetting.tsx
  - 룸 설정 창 UI 구성
- client/src/routes.tsx
  - /roomsetting 경로로 RoomSetting 페이지 라우터 설정

<!-- Concerns, etc. -->

## Extra Comments

룸 설정 창은 페이지로 구현하는 것이 아니라 컴포넌트로 구현되어야 할 것 같습니다.
룸 페이지가 구성되면 룸 페이지에서 룸 설정 버튼 클릭 시 룸 페이지 내에서 룸 설정 창이 나오도록 하면 좋을 것 같습니다.
최대 문제 갯수나 랜덤 문제 출제 시 태그를 선택하는 것도 어떤 식으로 할지 의논해봅시다.

<!-- If applicable, add screenshots to help explain your changes -->

## Demo

https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/74997112/8205ce5d-2f82-4711-b787-5f8815b2aab1
