### PR TITLE
chore: docker-compose 파일에 민감한 정보 .env 파일로 추출하기

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,15 @@
+# or localhost when npm start without docker
+DB_HOSTNAME=mysql
+
+DB_PORT=3306
+DB_USERNAME=example_user
+DB_PASSWORD=example_password
+DB_NAME=example_dbname
+
+SERVER_PORT=4000
+CLIENT_PORT=4176
+
+MYSQL_DATABASE=example_dbname
+MYSQL_USER=example_user
+MYSQL_PASSWORD=example_password
+MYSQL_ROOT_PASSWORD=example_root_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,38 +3,35 @@ version: '3.8'
 services:
   client:
     container_name: client
+    image: boj-client-img
     build:
       context: ./client
     ports:
-      - '4173:4173'
+      - '${CLIENT_PORT}:${CLIENT_PORT}'
+    env_file:
+      - ./.env
 
   server:
+    image: boj-server-img
     container_name: server
     build:
       context: ./server
-    environment:
-      - DB_HOSTNAME=mysql
-      - DB_PORT=3306
-      - DB_USERNAME=bojrooms
-      - DB_PASSWORD=bojroomssecret123!@#
-      - DB_NAME=bojrooms
     ports:
-      - '4000:4000'
+      - '${SERVER_PORT}:${SERVER_PORT}'
     depends_on:
       - mysql
+    env_file:
+      - ./.env
 
   mysql:
     container_name: mysql
     image: mysql
-    environment:
-      MYSQL_DATABASE: bojrooms
-      MYSQL_USER: bojrooms
-      MYSQL_PASSWORD: bojroomssecret123!@#
-      MYSQL_ROOT_PASSWORD: bojroomssecret123!@#
     ports:
-      - '3306:3306'
+      - '${DB_PORT}:${DB_PORT}'
     volumes:
       - mysql_data:/var/lib/mysql
+    env_file:
+      - ./.env
 
 volumes:
   mysql_data:


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?
- [x] **Rebase:** (필요시) rebase를 완료했나요?
- [x] **Conflict Resolution:** 충돌을 해결하는 과정을 거쳤나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

docker-compose.yml에 들어있는 유저 정보, 비밀번호, 포트 번호와 같은 정보들을 .env로 추출했습니다.

## Extra

일단 로컬에서 돌리려면

```bash
set -a; source ../.env; set +a && export DB_HOSTNAME=localhost && npm start
```

하면 잘 돌아갑니다!

## Demo

![image](https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/18080546/cb08846a-3f89-4405-aa2d-ddbc1458b9d8)

로컬에서 잘 동작하는 모습입니다.

## Issue

closes #54 


