### PR TITLE
fix(docker-compose.yml): .env -> ./server/.env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - '${CLIENT_PORT}:${CLIENT_PORT}'
     env_file:
-      - ./.env
+      - ./client/.env
 
   server:
     image: boj-server-img
@@ -21,7 +21,9 @@ services:
     depends_on:
       - mysql
     env_file:
-      - ./.env
+      - ./server/.env
+    environment:
+      - DB_HOSTNAME=mysql
 
   mysql:
     container_name: mysql
@@ -31,7 +33,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     env_file:
-      - ./.env
+      - ./server/.env
 
 volumes:
   mysql_data:


### PR DESCRIPTION

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?
- [x] **Rebase:** (필요시) rebase를 완료했나요?
- [x] **Conflict Resolution:** 충돌을 해결하는 과정을 거쳤나요?
- [x] **New Dependencies:** 새로운 dependency를 추가했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

#71 에서 최상위 .env를 지웠고,

```
env_file:
 - ./.env -> -./server/.env
```

대신 각 프로젝트 디렉토리의 .env를 사용하도록 변경합니다.

용이한 테스트 및 로컬 개발 환경을 위해서 server / client의 .env를 분리했습니다.

또한 server에 추가로 environment: DB_HOSTNAME=mysql을 추가해 .env를 덮어씌우도록 설정합니다.

## 장점 
```sh
# case 1
docker compose up --build # DB_HOSTNAME=mysql

# case 2
npm start # DB_HOSTNAME=localhost
```

자동으로 실행 환경에 맞게 DB_HOSTNAME을 변경할 수 있습니다.

