### PR TITLE
feat/nginx : 리버스 프록싱을 통한 서브도메인 별 다른 포트 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,16 @@ services:
     env_file:
       - ./server/.env
 
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - client
+      - server
+      
 volumes:
   mysql_data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,20 +5,20 @@ events {
 http {
     server {
         listen 80;
-        server_name api.beakjoonrooms.com;
+        server_name baekjoonrooms.com;
 
         location / {
-            proxy_pass http://223.130.146.179:4000;
+            proxy_pass http://223.130.146.179:4173;
             # Add additional proxy settings if needed
         }
     }
 
     server {
         listen 80;
-        server_name beakjoonrooms.com;
+        server_name api.baekjoonrooms.com;
 
         location / {
-            proxy_pass http://223.130.146.179:4173;
+            proxy_pass http://223.130.146.179:4000;
             # Add additional proxy settings if needed
         }
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name api.beakjoonrooms.com;
+
+        location / {
+            proxy_pass http://223.130.146.179:4000;
+            # Add additional proxy settings if needed
+        }
+    }
+
+    server {
+        listen 80;
+        server_name beakjoonrooms.com;
+
+        location / {
+            proxy_pass http://223.130.146.179:4173;
+            # Add additional proxy settings if needed
+        }
+    }
+}


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

nginx를 이용한 리버스 프록싱을 통해 baekjoonrooms.com은 4173 포트로, api.baekjoonrooms.com은 4000 포트로 이어지도록 변경합니다. 

close #85 
