### PR TITLE
Feat/room/logic : 룸 페이지 로직 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "Parens",
     "tailwindcss",
     "tanstack",
+    "toastify",
     "typeorm",
     "Xmark"
   ]

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.12.0",
-        "react-router-dom": "^6.18.0"
+        "react-router-dom": "^6.18.0",
+        "react-toastify": "^9.1.3"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
@@ -1602,6 +1603,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -3257,6 +3266,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
-    "react-router-dom": "^6.18.0"
+    "react-router-dom": "^6.18.0",
+    "react-toastify": "^9.1.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/client/src/components/RoomInfo.tsx
+++ b/client/src/components/RoomInfo.tsx
@@ -1,17 +1,30 @@
 import CreateRoom from '../../public/mocks/CreateRoom.json';
 import ExitButton from './buttons/ExitButton';
 import { FaRegCopy } from 'react-icons/fa6';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 export default function RoomInfo() {
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(CreateRoom.code);
+    toast.success('Copied to clipboard!', {
+      position: 'bottom-center',
+      autoClose: 2000,
+      hideProgressBar: true,
+    });
+  };
   return (
-    <div className="flex w-full items-center justify-between">
-      <div className="flex flex-row items-center rounded-lg text-aod_text">
-        <div className="pr-3 text-xl font-bold">{CreateRoom.code}</div>
-        <button>
-          <FaRegCopy />
-        </button>
+    <>
+      <div className="flex w-full items-center justify-between">
+        <div className="flex flex-row items-center rounded-lg text-aod_text">
+          <div className="pr-3 text-xl font-bold">{CreateRoom.code}</div>
+          <button onClick={copyToClipboard}>
+            <FaRegCopy />
+          </button>
+        </div>
+        <ExitButton />
       </div>
-      <ExitButton />
-    </div>
+      <ToastContainer toastClassName={'bg-aod_fg text-aod_text'} />
+    </>
   );
 }

--- a/client/src/components/ScoreBoardModal/ScoreBoardModal.tsx
+++ b/client/src/components/ScoreBoardModal/ScoreBoardModal.tsx
@@ -35,7 +35,7 @@ export default function ScoreBoardModal({
       ref={modalOverlayRef}
       onClick={modalOutsideClick}>
       <div className="relative flex h-[430px] w-[calc(50%-100px)] flex-col items-center rounded-2xl border-[0.5px] border-aod_gutter bg-aod_bg">
-        <button className="absolute top-4 right-4" onClick={closeModal}>
+        <button className="absolute right-4 top-4" onClick={closeModal}>
           <FaXmark style={iconStyle} />
         </button>
         <div className="flex w-full flex-col items-center gap-y-[2px] border-b-[0.5px] border-aod_gutter px-5 py-3">

--- a/client/src/components/ScoreBoardModal/ScoreBoardModal.tsx
+++ b/client/src/components/ScoreBoardModal/ScoreBoardModal.tsx
@@ -1,7 +1,14 @@
 import { ResultType, ScoreType } from '../../types/ScoreType';
 import mockScoresData from '../../../public/mocks/Scores.json';
 import ScoreBoard from './ScoreBoard';
-import { FaChartSimple } from 'react-icons/fa6';
+import { FaChartSimple, FaXmark } from 'react-icons/fa6';
+import { RefObject } from 'react';
+
+interface ModalProps {
+  modalOverlayRef: RefObject<HTMLDivElement>;
+  closeModal: () => void;
+  modalOutsideClick: (arg: React.MouseEvent<HTMLDivElement>) => void;
+}
 
 const mockScores: ScoreType = {
   players: mockScoresData.players.map((player) => ({
@@ -12,18 +19,34 @@ const mockScores: ScoreType = {
   })),
 };
 
-export default function ScoreBoardModal() {
-  return (
-    <div className="flex h-[430px] w-[330px] flex-col items-center rounded-2xl bg-aod_bg">
-      <div className="flex w-full flex-col items-center gap-y-[2px] border-b-[0.5px] border-aod_gutter px-5 py-3">
-        <div className="flex flex-row items-baseline gap-2">
-          <FaChartSimple />
-          <div className="text-lg font-medium text-aod_text">Scoreboard</div>
-        </div>
-        <div className="text-xs text-aod_text">3 online</div>
-      </div>
+const iconStyle = {
+  fontSize: '1.5rem',
+};
 
-      <ScoreBoard scores={mockScores}></ScoreBoard>
+export default function ScoreBoardModal({
+  modalOverlayRef,
+  closeModal,
+  modalOutsideClick,
+}: ModalProps) {
+  return (
+    <div
+      className="absolute left-0 top-0 z-50 flex h-full w-full items-center justify-center bg-aod_bg/80"
+      style={{ backdropFilter: 'blur(10px)' }}
+      ref={modalOverlayRef}
+      onClick={modalOutsideClick}>
+      <div className="relative flex h-[430px] w-[calc(50%-100px)] flex-col items-center rounded-2xl border-[0.5px] border-aod_gutter bg-aod_bg">
+        <button className="absolute top-4 right-4" onClick={closeModal}>
+          <FaXmark style={iconStyle} />
+        </button>
+        <div className="flex w-full flex-col items-center gap-y-[2px] border-b-[0.5px] border-aod_gutter px-5 py-3">
+          <div className="flex flex-row items-baseline gap-2">
+            <FaChartSimple />
+            <div className="text-lg font-medium text-aod_text">Scoreboard</div>
+          </div>
+          <div className="text-xs text-aod_text">3 online</div>
+        </div>
+        <ScoreBoard scores={mockScores}></ScoreBoard>
+      </div>
     </div>
   );
 }

--- a/client/src/components/buttons/ExitButton.tsx
+++ b/client/src/components/buttons/ExitButton.tsx
@@ -2,7 +2,7 @@ import { RxExit } from 'react-icons/rx';
 
 export default function ExitButton() {
   return (
-    <button className="flex flex-row items-center gap-x-2 rounded-lg bg-aod_accent px-2.5 py-1 text-aod_white hover:opacity-80">
+    <button className="flex flex-row items-center gap-x-2 rounded-lg bg-aod_accent px-2.5 py-1 text-aod_white hover:opacity-80" onClick={exit}>
       <RxExit
         style={{
           fontWeight: 'bold',
@@ -11,4 +11,8 @@ export default function ExitButton() {
       <div className="font-medium ">Exit</div>
     </button>
   );
+}
+
+function exit() {
+  window.location.href = '/lobby';
 }

--- a/client/src/components/buttons/ExitButton.tsx
+++ b/client/src/components/buttons/ExitButton.tsx
@@ -1,9 +1,12 @@
 import { RxExit } from 'react-icons/rx';
+import { useNavigate } from 'react-router-dom';
 
 export default function ExitButton() {
-  const exit =() => {
-    window.location.href = '/lobby';
-  }
+  const navigate = useNavigate();
+
+  const exit = () => {
+    navigate(`/lobby`);
+  };
   return (
     <button
       className="flex flex-row items-center gap-x-2 rounded-lg bg-aod_accent px-2.5 py-1 text-aod_white hover:opacity-80"
@@ -17,5 +20,3 @@ export default function ExitButton() {
     </button>
   );
 }
-
-

--- a/client/src/components/buttons/ExitButton.tsx
+++ b/client/src/components/buttons/ExitButton.tsx
@@ -1,6 +1,9 @@
 import { RxExit } from 'react-icons/rx';
 
 export default function ExitButton() {
+  const exit =() => {
+    window.location.href = '/lobby';
+  }
   return (
     <button
       className="flex flex-row items-center gap-x-2 rounded-lg bg-aod_accent px-2.5 py-1 text-aod_white hover:opacity-80"
@@ -15,6 +18,4 @@ export default function ExitButton() {
   );
 }
 
-function exit() {
-  window.location.href = '/lobby';
-}
+

--- a/client/src/components/buttons/ExitButton.tsx
+++ b/client/src/components/buttons/ExitButton.tsx
@@ -2,7 +2,9 @@ import { RxExit } from 'react-icons/rx';
 
 export default function ExitButton() {
   return (
-    <button className="flex flex-row items-center gap-x-2 rounded-lg bg-aod_accent px-2.5 py-1 text-aod_white hover:opacity-80" onClick={exit}>
+    <button
+      className="flex flex-row items-center gap-x-2 rounded-lg bg-aod_accent px-2.5 py-1 text-aod_white hover:opacity-80"
+      onClick={exit}>
       <RxExit
         style={{
           fontWeight: 'bold',

--- a/client/src/components/buttons/ScoreBoardButton.tsx
+++ b/client/src/components/buttons/ScoreBoardButton.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from 'react';
 export default function ScoreboardButton() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const modalOverlayRef = useRef<HTMLDivElement>(null);
-  
+
   const openModal = () => {
     setIsModalOpen(true);
   };
@@ -26,7 +26,15 @@ export default function ScoreboardButton() {
         <FaChartSimple />
         <div className="pl-2 font-medium">Scoreboard</div>
       </button>
-      {isModalOpen ? <ScoreBoardModal modalOverlayRef={modalOverlayRef} closeModal={closeModal} modalOutsideClick={modalOutsideClick}/> : <></>}
+      {isModalOpen ? (
+        <ScoreBoardModal
+          modalOverlayRef={modalOverlayRef}
+          closeModal={closeModal}
+          modalOutsideClick={modalOutsideClick}
+        />
+      ) : (
+        <></>
+      )}
     </>
   );
 }

--- a/client/src/components/buttons/ScoreBoardButton.tsx
+++ b/client/src/components/buttons/ScoreBoardButton.tsx
@@ -1,10 +1,32 @@
 import { FaChartSimple } from 'react-icons/fa6';
+import ScoreBoardModal from '../ScoreBoardModal/ScoreBoardModal';
+import { useRef, useState } from 'react';
 
 export default function ScoreboardButton() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const modalOverlayRef = useRef<HTMLDivElement>(null);
+  
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const modalOutsideClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (modalOverlayRef.current === event.target) {
+      setIsModalOpen(false);
+    }
+  };
   return (
-    <button className="flex w-full flex-row items-center justify-center rounded-lg bg-aod_accent px-3 py-2 text-aod_white hover:opacity-80">
-      <FaChartSimple />
-      <div className="pl-2 font-medium">Scoreboard</div>
-    </button>
+    <>
+      <button
+        className="flex w-full flex-row items-center justify-center rounded-lg bg-aod_accent px-3 py-2 text-aod_white hover:opacity-80"
+        onClick={openModal}>
+        <FaChartSimple />
+        <div className="pl-2 font-medium">Scoreboard</div>
+      </button>
+      {isModalOpen ? <ScoreBoardModal modalOverlayRef={modalOverlayRef} closeModal={closeModal} modalOutsideClick={modalOutsideClick}/> : <></>}
+    </>
   );
 }


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **New Dependencies:** 새로운 dependency를 추가했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description
close #90
룸 페이지의 기능들을 추가했습니다.
<!-- List core changes that were made in this pull request -->

## Changes Made
- react-toastify dependency 추가
- client/src/components/RoomInfo.tsx : 룸 페이지 방 코드 복사 하기
- client/src/components/buttons/ExitButton.tsx : 나가기 버튼 로직
- client/src/components/ScoreBoardModal/ScoreBoardModal.tsx : 스코어보드 모달화
<!-- Concerns, etc. -->

## Extra Comments

<!-- If applicable, add screenshots to help explain your changes -->

## Demo
![Nov-28-2023 16-32-06](https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/63452858/14573f9a-70eb-4bab-b423-d6b93700aeea)



