### PR TITLE
hotfix: server 배포에서 돌아가도록 핫 픽스: 프론트 env 파일, auth callback url 관련 픽스

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,5 +1,5 @@
 node_modules
-*.env*
+# *.env*
 dist
 Dockerignore
 *.log

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -11,7 +11,7 @@ export class AuthController {
 
   @Get('github/callback')
   @UseGuards(GithubAuthGuard)
-  @Redirect('http://localhost:5173/home')
+  @Redirect('http://baekjoonrooms.com/home')
   async authCallback(@Req() req) {
     return 'login success!';
   }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -8,7 +8,7 @@ import * as cookieParser from 'cookie-parser';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     cors: {
-      origin: 'http://localhost:5173',
+      origin: 'http://baekjoonrooms.com',
       methods: 'GET ,HEAD, PUT, PATCH, POST, DELETE',
       allowedHeaders: 'Content-Type, Accept',
       credentials: true,


### PR DESCRIPTION
## Description

배포 서버에서 정상적으로 돌아가기 위해

- OAuth callback URL을 바꿔준다.
- localhost -> baekjoon.com 으로 바꿔서 CORS를 열어준다.
- client의 .dockreignore에서 .env를 이미지에 포함할 수 있도록 바꿔준다. 이유: vite는 빌드 타임에 .env를 상수로 바꾸고, runtime에 불러오지 않는다.