### PR TITLE
feat/create-room : 방 생성 API

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { PassportModule } from '@nestjs/passport';
 import { UserModule } from './user/user.module';
 import { SocketModule } from './socket/socket.module';
+import { RoomModule } from './room/room.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { SocketModule } from './socket/socket.module';
     AuthModule,
     UserModule,
     SocketModule,
+    RoomModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/server/src/entities/room.entity.ts
+++ b/server/src/entities/room.entity.ts
@@ -24,7 +24,11 @@ export default class Room extends BaseEntity {
   @Column()
   code: string;
 
-  @Column({ type: 'timestamp', comment: '방 내 대회 만료 시간' })
+  @Column({
+    type: 'timestamp',
+    nullable: true,
+    comment: '방 내 대회 만료 시간',
+  })
   endAt: Date;
 
   @CreateDateColumn({ type: 'timestamp' })
@@ -36,7 +40,7 @@ export default class Room extends BaseEntity {
   @DeleteDateColumn({ type: 'timestamp', nullable: true })
   deletedAt: Date;
 
-  @OneToOne(() => User)
+  @OneToOne(() => User, { nullable: false })
   @JoinColumn()
   host: User;
 

--- a/server/src/room/dto/create.room.dto.ts
+++ b/server/src/room/dto/create.room.dto.ts
@@ -1,6 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumber } from 'class-validator';
 
 export class CreateRoomDto {
+  @ApiProperty({
+    example: 1,
+    required: true,
+  })
   @IsNumber()
   @IsNotEmpty()
   userId: number;

--- a/server/src/room/dto/create.room.dto.ts
+++ b/server/src/room/dto/create.room.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreateRoomDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+}

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('room')
+export class RoomController {}

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -1,16 +1,21 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { RoomService } from './room.service';
 import { CreateRoomDto } from './dto/create.room.dto';
-import { UserService } from 'src/user/user.service';
+import { RoomService } from './room.service';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @Controller('room')
+@ApiTags('room')
 export class RoomController {
-  constructor(
-    private readonly roomService: RoomService,
-    private readonly userService: UserService,
-  ) {}
+  constructor(private readonly roomService: RoomService) {}
 
   @Post()
+  @ApiOperation({
+    summary: '방 생성',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '이미 참가하고 있는 방이 있는데 방 생성을 시도한 경우',
+  })
   async createRoom(@Body() createRoomDto: CreateRoomDto) {
     return await this.roomService.createRoom(createRoomDto);
   }

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -1,4 +1,17 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import { RoomService } from './room.service';
+import { CreateRoomDto } from './dto/create.room.dto';
+import { UserService } from 'src/user/user.service';
 
 @Controller('room')
-export class RoomController {}
+export class RoomController {
+  constructor(
+    private readonly roomService: RoomService,
+    private readonly userService: UserService,
+  ) {}
+
+  @Post()
+  async createRoom(@Body() createRoomDto: CreateRoomDto) {
+    return await this.roomService.createRoom(createRoomDto);
+  }
+}

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RoomController } from './room.controller';
+import { RoomService } from './room.service';
+
+@Module({
+  controllers: [RoomController],
+  providers: [RoomService]
+})
+export class RoomModule {}

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { RoomController } from './room.controller';
 import { RoomService } from './room.service';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
+  imports: [UserModule],
   controllers: [RoomController],
-  providers: [RoomService]
+  providers: [RoomService],
 })
 export class RoomModule {}

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { RoomController } from './room.controller';
 import { RoomService } from './room.service';
 import { UserModule } from 'src/user/user.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import Room from 'src/entities/room.entity';
 
 @Module({
-  imports: [UserModule],
+  imports: [UserModule, TypeOrmModule.forFeature([Room])],
   controllers: [RoomController],
   providers: [RoomService],
 })

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { RoomController } from './room.controller';
-import { RoomService } from './room.service';
-import { UserModule } from 'src/user/user.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import Room from 'src/entities/room.entity';
+import { UserModule } from 'src/user/user.module';
+import { RoomController } from './room.controller';
+import { RoomService } from './room.service';
 
 @Module({
   imports: [UserModule, TypeOrmModule.forFeature([Room])],

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RoomService {}

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -1,4 +1,37 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import Room from 'src/entities/room.entity';
+import { Repository } from 'typeorm';
+import { CreateRoomDto } from './dto/create.room.dto';
+import { UserService } from 'src/user/user.service';
+import * as crypto from 'crypto';
 
 @Injectable()
-export class RoomService {}
+export class RoomService {
+  constructor(
+    @InjectRepository(Room)
+    private readonly roomRepository: Repository<Room>,
+    private readonly userService: UserService,
+  ) {}
+
+  async createRoom(createRoomDto: CreateRoomDto) {
+    const user = await this.userService.findUserWithRoomById(
+      createRoomDto.userId,
+    );
+    if (user.joinedRoom)
+      throw new BadRequestException('이미 방에 참가 중입니다.');
+
+    const roomCode = await this.createRoomCode(user.username);
+
+    return this.roomRepository
+      .create({ code: roomCode, host: user, users: [user] })
+      .save();
+  }
+
+  async createRoomCode(username: string) {
+    const currentTime = Date.now();
+    const hashSource = `${username}${currentTime}`;
+    const hash = crypto.createHash('sha256').update(hashSource).digest('hex');
+    return hash.substring(0, 6).toUpperCase();
+  }
+}

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -1,10 +1,10 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import * as crypto from 'crypto';
 import Room from 'src/entities/room.entity';
+import { UserService } from 'src/user/user.service';
 import { Repository } from 'typeorm';
 import { CreateRoomDto } from './dto/create.room.dto';
-import { UserService } from 'src/user/user.service';
-import * as crypto from 'crypto';
 
 @Injectable()
 export class RoomService {

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CreateUserDto } from './dto/create.user.dto';
 import { UserService } from './user.service';
 
@@ -11,6 +11,10 @@ export class UserController {
   @Post()
   @ApiOperation({
     summary: '유저 생성',
+  })
+  @ApiResponse({
+    status: 400,
+    description: '이미 존재하는 유저인 경우',
   })
   async createUser(@Body() createUserDto: CreateUserDto) {
     return await this.userService.createUser(createUserDto);

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -25,4 +25,8 @@ export class UserService {
       where: providerInfo,
     });
   }
+
+  async findUserById(id: number) {
+    return this.userRepository.findOneBy({ id });
+  }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -26,7 +26,10 @@ export class UserService {
     });
   }
 
-  async findUserById(id: number) {
-    return this.userRepository.findOneBy({ id });
+  async findUserWithRoomById(id: number) {
+    return this.userRepository.findOne({
+      where: { id },
+      relations: ['joinedRoom'],
+    });
   }
 }


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

1. 방 생성 api를 만들었는데 개발의 편의를 위해 아직 auth 데코레이터는 붙이지 않았습니다.
2. 방 생성 api의 경우, user가 참여하고 있는 방이 있다면 400에러를 띄우고 아니면 참여한 룸의 정보를 일단 모두 보여줍니다.
3. 코드는 username과 현재 시각을 해시한 값의 첫 6자리를 가져옵니다. 코드의 충돌을 최소화하기 위해 해시를 사용했습니다. 
4. 코드같은 경우 혹시 모를 중복을 피하기 위해, 방 종료 시 코드 정보를 삭제해야 할 지도 모르겠습니다.
5. 중간에 entity의 nullable 관련 설정을 약간 수정하였습니다. 

close #118 
