### PR TITLE
feat/change-user-room-relation : user와 room 사이에 many to many 관계 추가

### DIFF
--- a/server/src/entities/room.entity.ts
+++ b/server/src/entities/room.entity.ts
@@ -12,6 +12,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import Problem from './problem.entity';
+import RoomUser from './roomUser.entity';
 import Submission from './submission.entity';
 import User from './user.entity';
 
@@ -45,9 +46,8 @@ export default class Room extends BaseEntity {
   })
   host: User;
 
-  // 이 방에 참가한 사람들
-  @OneToMany(() => User, (user) => user.joinedRoom)
-  users: User[];
+  @OneToMany(() => RoomUser, (roomUser) => roomUser.room)
+  joinedUsers: RoomUser[];
 
   @OneToMany(() => Submission, (submission) => submission.room)
   submissions: Submission[];

--- a/server/src/entities/roomUser.entity.ts
+++ b/server/src/entities/roomUser.entity.ts
@@ -3,28 +3,24 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
-  JoinColumn,
+  Index,
   ManyToOne,
-  PrimaryColumn,
+  PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import Room from './room.entity';
 import User from './user.entity';
 
 @Entity()
+@Index(['room', 'user'], { unique: true })
 export default class RoomUser extends BaseEntity {
-  @PrimaryColumn()
-  roomId: number;
-
-  @PrimaryColumn()
-  userId: number;
+  @PrimaryGeneratedColumn()
+  id: number;
 
   @ManyToOne(() => Room, (room) => room.joinedUsers)
-  @JoinColumn({ name: 'room_id', referencedColumnName: 'id' })
   room: Room;
 
   @ManyToOne(() => User, (user) => user.joinedRooms)
-  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
   user: User;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/server/src/entities/roomUser.entity.ts
+++ b/server/src/entities/roomUser.entity.ts
@@ -1,0 +1,38 @@
+import {
+  BaseEntity,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import Room from './room.entity';
+import User from './user.entity';
+
+@Entity()
+export default class RoomUser extends BaseEntity {
+  @PrimaryColumn()
+  roomId: number;
+
+  @PrimaryColumn()
+  userId: number;
+
+  @ManyToOne(() => Room, (room) => room.joinedUsers)
+  @JoinColumn({ name: 'room_id', referencedColumnName: 'id' })
+  room: Room;
+
+  @ManyToOne(() => User, (user) => user.joinedRooms)
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: User;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp', nullable: true })
+  updatedAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamp', nullable: true })
+  deletedAt: Date;
+}

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -5,12 +5,12 @@ import {
   DeleteDateColumn,
   Entity,
   Index,
-  ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import Room from './room.entity';
+import RoomUser from './roomUser.entity';
 import Submission from './submission.entity';
 
 @Entity()
@@ -40,11 +40,8 @@ export default class User extends BaseEntity {
   @DeleteDateColumn({ type: 'timestamp', nullable: true })
   deletedAt: Date;
 
-  @ManyToOne(() => Room, (room) => room.users, {
-    cascade: true,
-    nullable: true,
-  })
-  joinedRoom: Room;
+  @OneToMany(() => RoomUser, (roomUser) => roomUser.user)
+  joinedRooms: RoomUser[];
 
   @OneToMany(() => Submission, (submission) => submission.user)
   submissions: Submission[];

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import Room from 'src/entities/room.entity';
+import { RoomUserModule } from 'src/roomUser/room.user.module';
 import { UserModule } from 'src/user/user.module';
 import { RoomController } from './room.controller';
 import { RoomService } from './room.service';
 
 @Module({
-  imports: [UserModule, TypeOrmModule.forFeature([Room])],
+  imports: [UserModule, RoomUserModule, TypeOrmModule.forFeature([Room])],
   controllers: [RoomController],
   providers: [RoomService],
 })

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as crypto from 'crypto';
 import Room from 'src/entities/room.entity';
+import { RoomUserService } from 'src/roomUser/room.user.service';
 import { UserService } from 'src/user/user.service';
 import { Repository } from 'typeorm';
 import { CreateRoomDto } from './dto/create.room.dto';
@@ -11,22 +12,32 @@ export class RoomService {
   constructor(
     @InjectRepository(Room)
     private readonly roomRepository: Repository<Room>,
+
     private readonly userService: UserService,
+    private readonly roomUserService: RoomUserService,
   ) {}
 
   async createRoom(createRoomDto: CreateRoomDto) {
-    const user = await this.userService.findUserWithRoomById(
+    const user = await this.userService.findUserWithActiveRoomById(
       createRoomDto.userId,
     );
     if (!user) throw new BadRequestException('존재하지 않는 유저입니다.');
-    if (user.joinedRoom)
+
+    if (user.joinedRooms.length > 0)
       throw new BadRequestException('이미 방에 참가 중입니다.');
 
+    // 방 코드 생성 -> 방 생성 -> host를 참여자로 추가, -> 방 반환
     const roomCode = await this.createRoomCode(user.username);
-
-    return this.roomRepository
-      .create({ code: roomCode, host: user, users: [user] })
+    const room = await this.roomRepository
+      .create({
+        code: roomCode,
+        host: user,
+        joinedUsers: [user],
+      })
       .save();
+    await this.roomUserService.createRoomUser({ room, user });
+
+    return room;
   }
 
   async createRoomCode(username: string) {

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -26,7 +26,7 @@ export class RoomService {
     if (user.joinedRooms.length > 0)
       throw new BadRequestException('이미 방에 참가 중입니다.');
 
-    // 방 코드 생성 -> 방 생성 -> host를 참여자로 추가, -> 방 반환
+    // 방 코드 생성 -> 방 생성 -> host를 참여자로 추가 -> 방 반환
     const roomCode = await this.createRoomCode(user.username);
     const room = await this.roomRepository
       .create({

--- a/server/src/roomUser/room.user.module.ts
+++ b/server/src/roomUser/room.user.module.ts
@@ -7,5 +7,6 @@ import { RoomUserService } from './room.user.service';
   imports: [TypeOrmModule.forFeature([RoomUser])],
   controllers: [],
   providers: [RoomUserService],
+  exports: [RoomUserService],
 })
 export class RoomUserModule {}

--- a/server/src/roomUser/room.user.module.ts
+++ b/server/src/roomUser/room.user.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import RoomUser from 'src/entities/roomUser.entity';
+import { RoomUserService } from './room.user.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RoomUser])],
+  controllers: [],
+  providers: [RoomUserService],
+})
+export class RoomUserModule {}

--- a/server/src/roomUser/room.user.service.ts
+++ b/server/src/roomUser/room.user.service.ts
@@ -1,9 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import * as crypto from 'crypto';
 import RoomUser from 'src/entities/roomUser.entity';
-import { Repository } from 'typeorm';
 import { CreateRoomUserInput } from 'src/types/roomUser';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class RoomUserService {

--- a/server/src/roomUser/room.user.service.ts
+++ b/server/src/roomUser/room.user.service.ts
@@ -1,0 +1,18 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as crypto from 'crypto';
+import RoomUser from 'src/entities/roomUser.entity';
+import { Repository } from 'typeorm';
+import { CreateRoomUserInput } from 'src/types/roomUser';
+
+@Injectable()
+export class RoomUserService {
+  constructor(
+    @InjectRepository(RoomUser)
+    private readonly roomUserRepository: Repository<RoomUser>,
+  ) {}
+
+  async createRoomUser(createRoomUserInput: CreateRoomUserInput) {
+    return this.roomUserRepository.create(createRoomUserInput).save();
+  }
+}

--- a/server/src/types/roomUser.ts
+++ b/server/src/types/roomUser.ts
@@ -1,0 +1,7 @@
+import Room from 'src/entities/room.entity';
+import User from 'src/entities/user.entity';
+
+export interface CreateRoomUserInput {
+  room: Room;
+  user: User;
+}

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -26,10 +26,10 @@ export class UserService {
     });
   }
 
-  async findUserWithRoomById(id: number) {
+  async findUserWithActiveRoomById(id: number) {
     return this.userRepository.findOne({
-      where: { id },
-      relations: ['joinedRoom'],
+      where: { id, joinedRooms: { deletedAt: null } },
+      relations: { joinedRooms: true },
     });
   }
 }


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

1. user와 room 사이의 many to many 관계를 데코레이터를 이용하지 않고 user와 RoomUser간에 또 room과 RoomUser간에 관계를 만들어서 생성했습니다.
2. pk를 room과 user id의 복합키로 만들고 싶었으나 쉽지 않았던 관계로 별도의 pk를 생성했고 복합키는 index로 걸어두었습니다.
3. entity 변경의 결과로 user service와 room service의 로직을 일부 변경하였으며, roomUser 모듈을 별도로 추가하였습니다.

close #138 

## Demo
생성된 room user 디비는 다음과 같습니다.
![image](https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/71765155/9c402df0-96e7-47f2-9542-654478825ec1)
