### PR TITLE
feat(socket & auth): socket io 연결 시 passport 인증 성공

### DIFF
--- a/server/src/socket/socket.adapter.ts
+++ b/server/src/socket/socket.adapter.ts
@@ -1,0 +1,30 @@
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { INestApplicationContext } from '@nestjs/common';
+import { RequestHandler } from 'express';
+import * as passport from 'passport';
+
+export class SocketIOAdapter extends IoAdapter {
+  private readonly session: RequestHandler;
+  constructor(session: RequestHandler, app: INestApplicationContext) {
+    super(app);
+    this.session = session;
+  }
+
+  create(port: number, options?: any): any {
+    const server = super.createIOServer(port, options);
+
+    const wrap = (middleware) => (socket, next) =>
+      middleware(socket.request, {}, next);
+
+    server.use((socket, next) => {
+      socket.data.username = 'test';
+      next();
+    });
+
+    server.use(wrap(this.session));
+    server.use(wrap(passport.initialize()));
+    server.use(wrap(passport.session()));
+
+    return server;
+  }
+}

--- a/server/src/socket/socket.gateway.ts
+++ b/server/src/socket/socket.gateway.ts
@@ -10,7 +10,9 @@ import {
 import { Server, Socket } from 'socket.io';
 import { MessageInterface } from '../types/MessageInterface';
 import * as util from 'util';
-import { Logger } from '@nestjs/common';
+import { Logger, UseGuards } from '@nestjs/common';
+import { UserService } from '../user/user.service';
+import { SessionAuthGuard } from '../auth/auth.guard';
 
 @WebSocketGateway({
   cors: {
@@ -25,8 +27,15 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private readonly logger = new Logger(SocketGateway.name);
 
+  constructor(private readonly userService: UserService) {}
+
+  @UseGuards(SessionAuthGuard)
   handleConnection(@ConnectedSocket() client: Socket) {
+    const request = client.request as any;
+    this.logger.debug(`${util.inspect(request.user)}`);
+
     this.logger.debug(`client ${client.id} connected`);
+
     client.join('RM1234');
   }
 

--- a/server/src/socket/socket.module.ts
+++ b/server/src/socket/socket.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { SocketGateway } from './socket.gateway';
+import { UserModule } from '../user/user.module';
 
 @Module({
   providers: [SocketGateway],
+  imports: [UserModule],
 })
 export class SocketModule {}


### PR DESCRIPTION
useWebsocketAdapter와 IOAdapter를 사용하여, io 서버가 내부적으로 passport, session을 사용하도록 설정한다.


## 참고 자료

[Passport session authentication with websockets and Nest.js not authenticating](https://stackoverflow.com/questions/68684439/passport-session-authentication-with-websockets-and-nest-js-not-authenticating)

[10 - Authorizing Socket.io Connections In NestJS](https://www.youtube.com/watch?v=tUNaSRa5CFA)

[Support adding guards on gateway’s handleConnection method](https://github.com/nestjs/nest/issues/882#top)

참고.