### PR TITLE
feat(WsExceptionFilter): 전역 WS 에러 핸들링 지원 추가

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -30,7 +30,7 @@ import { SubmissionModule } from './submission/submission.module';
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
       entities: [__dirname + '/**/*.entity.*'],
-      logging: true,
+      logging: false,
       synchronize: true, // production시 false로 변경
       namingStrategy: new SnakeNamingStrategy(),
     }),

--- a/server/src/socket/socket.filter.ts
+++ b/server/src/socket/socket.filter.ts
@@ -4,9 +4,17 @@ import { BaseWsExceptionFilter } from '@nestjs/websockets';
 @Catch()
 export class WebsocketExceptionsFilter extends BaseWsExceptionFilter {
   private readonly logger = new Logger(WebsocketExceptionsFilter.name);
-
   catch(exception: unknown, host: ArgumentsHost) {
-    this.logger.debug('this exception is handled by WebsocketExceptionsFilter');
+    if (exception instanceof Error) {
+      const { name, message, stack } = exception;
+
+      this.logger.error(
+        `IO server raises ${name}: Error Message: ${message}`,
+        stack,
+      );
+
+      this.logger.error(exception);
+    }
     super.catch(exception, host);
   }
 }

--- a/server/src/socket/socket.gateway.ts
+++ b/server/src/socket/socket.gateway.ts
@@ -18,7 +18,12 @@ import { WebsocketExceptionsFilter } from './socket.filter';
 
 @WebSocketGateway({
   cors: {
-    origin: [process.env.CLIENT_HTTP_URL, process.env.CLIENT_HTTPS_URL, process.env.CLIENT_URL, 'http://localhost:4000'],
+    origin: [
+      process.env.CLIENT_HTTP_URL,
+      process.env.CLIENT_HTTPS_URL,
+      process.env.CLIENT_URL,
+      'http://localhost:4000',
+    ],
     credentials: true,
   },
   transports: ['websocket', 'polling'],


### PR DESCRIPTION
useGlobalFilters는 HTTP 관련 요청을 처리할 때 생기는 에러를 잘 해결해주지만,
게이트웨이 관련 에러는 처리하지 못합니다. (공식 문서 참고)

gateway에서 발생하는 에러들을 전역으로 처리하는 로직을 따로 넣어줘야 합니다.
잘 안되는 게 있어서 지금까지는 try catch로 핸들링하고 있었는데, 디버깅이 끝났고 이제는 잘 됩니다.

여전히 handleConnection 함수에서 발생하는 에러는 직접 try catch로 잡아줘야 합니다. NestJS 깃허브에 따르면 이는 의도된 동작이라고 합니다.

그 외 기타: 
- 원격 서버에서 수정하느라 미처 프리티어가 적용되지 못한 cors origin을 포메팅해주었습니다.
- TypeORM 로그를 꺼서 로그를 간소화했습니다. 쿼리 최적화를 하지 않고 있는 단계이기 때문에 아직까지는 도움이 되지 않는다고 판단했습니다.