### PR TITLE
feat(submission, socket): 제출 TODO 구현: 1) 제출 통보 2) 제출 현황 알림

### DIFF
--- a/server/src/auth/auth.guard.ts
+++ b/server/src/auth/auth.guard.ts
@@ -41,7 +41,7 @@ export class MockAuthGuard extends AuthGuard('local') {
   private readonly logger = new Logger(MockAuthGuard.name);
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    this.logger.debug('[start] MockAuthGuard canActivate');
+    this.logger.debug('Mock Login request received!');
     const request = context.switchToHttp().getRequest();
     const isAuthenticated = request.isAuthenticated();
 
@@ -56,14 +56,15 @@ export class MockAuthGuard extends AuthGuard('local') {
 
     const result = (await super.canActivate(context)) as boolean;
 
-    if (result) {
-      this.logger.debug(`Now we ask passport to record this session...`);
-      await super.logIn(request);
-      this.logger.debug(`Session recording successful!`);
-    } else {
-      this.logger.fatal(`login failed!`);
+    if (!result) {
+      this.logger.log(`login failed!`);
+      return false;
     }
-    return result;
+
+    this.logger.debug(`Now we ask passport to record this session...`);
+    await super.logIn(request);
+    this.logger.debug(`Session recording successful!`);
+    return true;
   }
 }
 
@@ -77,10 +78,11 @@ export class SessionAuthGuard implements CanActivate {
   private readonly logger = new Logger(SessionAuthGuard.name);
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    this.logger.debug('start canActivate');
     const request = context.switchToHttp().getRequest();
     const isAuthenticated = request.isAuthenticated();
-    this.logger.debug(`isAuthenticated is ${isAuthenticated}`);
-    return request.isAuthenticated();
+    this.logger.debug(
+      `Is this request from authenticated user? ${isAuthenticated}`,
+    );
+    return isAuthenticated;
   }
 }

--- a/server/src/auth/auth.serializer.ts
+++ b/server/src/auth/auth.serializer.ts
@@ -22,8 +22,9 @@ export class LocalSerializer extends PassportSerializer {
   }
 
   async deserializeUser(userSession: UserSession, done: CallableFunction) {
-    this.logger.debug('Deserializing userSession:', userSession);
-    const { provider, providerId } = userSession;
+    this.logger.debug('Deserializing userSession...');
+    const { username, providerId, provider } = userSession;
+    this.logger.debug(util.inspect({ provider, providerId, username }));
     const user = await this.userService.findUserByProviderInfo({
       provider,
       providerId,

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  Logger,
-} from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { UserService } from '../user/user.service';
 import User from '../entities/user.entity';
 import { ProviderInfo } from 'src/types/user';
@@ -22,8 +18,8 @@ export class AuthService {
       await this.userService.findUserByProviderInfo(mockProviderInfo);
 
     if (user == null) {
-      this.logger.debug('유저가 존재하지 않습니다.');
-      throw new InternalServerErrorException();
+      this.logger.debug('잘못된 로그인 요청입니다!');
+      throw new BadRequestException('잘못된 로그인 요청입니다!');
     }
 
     return user;

--- a/server/src/entities/room.entity.ts
+++ b/server/src/entities/room.entity.ts
@@ -41,20 +41,19 @@ export default class Room extends BaseEntity {
   deletedAt?: Date;
 
   @ManyToOne(() => User, (user) => user.hostedRooms, {
-    cascade: true,
-
-    nullable: true,
+    lazy: true,
+    nullable: false,
   })
-  host?: User;
+  host?: Promise<User>;
 
   @OneToMany(() => RoomUser, (roomUser) => roomUser.room)
   joinedUsers?: RoomUser[];
 
-  @OneToMany(() => Submission, (submission) => submission.room)
-  submissions?: Submission[];
+  @OneToMany(() => Submission, (submission) => submission.room, { lazy: true })
+  submissions?: Promise<Submission[]>;
 
   // 이 방에서 출제된 문제들
-  @ManyToMany(() => Problem, (problem) => problem.rooms)
+  @ManyToMany(() => Problem, (problem) => problem.rooms, { lazy: true })
   @JoinTable()
-  problems?: Problem[];
+  problems?: Promise<Problem[]>;
 }

--- a/server/src/entities/submission.entity.ts
+++ b/server/src/entities/submission.entity.ts
@@ -32,7 +32,7 @@ export default class Submission extends BaseEntity {
   @ManyToOne(() => User, (user) => user.submissions, { cascade: true })
   user?: User;
 
-  @ManyToOne(() => Room, (room) => room.submissions, { cascade: true })
+  @ManyToOne(() => Room, (room) => room.submissions, { cascade: false })
   room?: Room;
 
   @ManyToOne(() => Problem, (problem) => problem.submissions, { cascade: true })

--- a/server/src/exceptions/exceptions.filter.ts
+++ b/server/src/exceptions/exceptions.filter.ts
@@ -1,5 +1,13 @@
-import { ArgumentsHost, Catch, HttpException, Logger } from '@nestjs/common';
+import {
+  ArgumentsHost,
+  BadRequestException,
+  Catch,
+  ForbiddenException,
+  HttpException,
+  Logger,
+} from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
+import * as util from 'util';
 
 @Catch()
 export class ExceptionsFilter extends BaseExceptionFilter {
@@ -9,11 +17,23 @@ export class ExceptionsFilter extends BaseExceptionFilter {
     if (exception instanceof HttpException) {
       const status = exception.getStatus();
       const { name, message, stack } = exception;
-
-      this.logger.error(
-        `Server raises ${name}: ${status} Error Message: ${message}`,
-        stack,
-      );
+      if (
+        exception instanceof BadRequestException ||
+        exception instanceof ForbiddenException
+      ) {
+        this.logger.warn(`Server raises ${name}: ${status}: ${message}`, stack);
+      } else {
+        this.logger.error(
+          `Server raises HttpException ${name}: ${status}: ${message}`,
+          stack,
+        );
+      }
+    } else if (exception instanceof Error) {
+      const { name, message, stack } = exception;
+      this.logger.error(`Server raises Error ${name}: ${message}`, stack);
+    } else {
+      this.logger.error(`Server raises an unknown exception...`);
+      this.logger.error(util.inspect(exception));
     }
 
     super.catch(exception, host);

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -39,12 +39,13 @@ export class RoomService {
     if (user.username == null)
       throw new BadRequestException('username이 없습니다.');
     const code = await this.createRoomCode(user.username);
-    const room = await this.roomRepository
-      .create({
-        code,
-        host: user,
-      })
-      .save();
+
+    this.logger.log(`creating room ${code}...`);
+    const room = new Room();
+    room.code = code;
+    room.host = Promise.resolve(user);
+    await this.roomRepository.save(room);
+    this.logger.log(`room ${code} successfully created by ${user.username}!`);
 
     await this.roomUserService.create({ room, user });
     return room;
@@ -79,7 +80,7 @@ export class RoomService {
   }
 
   async destroyRoom(room: Room) {
-    this.logger.debug(`destroying room: ${room.code}`);
+    this.logger.log(`destroying room: ${room.code}`);
     return await this.roomRepository.remove(room);
   }
 

--- a/server/src/socket/socket.filter.ts
+++ b/server/src/socket/socket.filter.ts
@@ -12,8 +12,8 @@ export class WebsocketExceptionsFilter extends BaseWsExceptionFilter {
         `IO server raises ${name}: Error Message: ${message}`,
         stack,
       );
-
-      this.logger.error(exception);
+    } else {
+      this.logger.error(`Server caught unknown type`, exception);
     }
     super.catch(exception, host);
   }

--- a/server/src/socket/socket.gateway.ts
+++ b/server/src/socket/socket.gateway.ts
@@ -9,12 +9,18 @@ import {
   WsException,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { MessageInterface } from '../types/MessageInterface';
+import { ChatEvent, MessageInterface } from '../types/MessageInterface';
 import { Logger, UseFilters, UseGuards } from '@nestjs/common';
 import { UserService } from '../user/user.service';
 import User from '../entities/user.entity';
 import { SessionAuthGuard } from 'src/auth/auth.guard';
 import { WebsocketExceptionsFilter } from './socket.filter';
+import { Status } from '../const/bojResults';
+
+export type GameStartInfo = {
+  problems: string[];
+  endTime: string;
+};
 
 @WebSocketGateway({
   cors: {
@@ -31,45 +37,164 @@ import { WebsocketExceptionsFilter } from './socket.filter';
 @UseFilters(WebsocketExceptionsFilter)
 export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
-  private readonly server?: Server;
+  private readonly server!: Server;
 
   private readonly logger = new Logger(SocketGateway.name);
 
   constructor(private readonly userService: UserService) {}
+
+  async handleDisconnect(@ConnectedSocket() client: Socket) {
+    try {
+      const user = this.getUser(client);
+      const message: Partial<MessageInterface> = {
+        username: 'system',
+        body: `${user.username}님이 퇴장하셨습니다.`,
+        timestamp: Date.now(),
+        chatEvent: ChatEvent.Leave,
+      };
+      const joinedRoom = await this.userService.getJoinedRoom(user);
+      const roomCode = joinedRoom.room.code;
+      this.logger.log(
+        `client ${user.username} leaving room ${roomCode} and disconnecting...`,
+      );
+      this.server.to(roomCode).emit('chat-message', message);
+    } catch (e) {
+      if (e instanceof WsException) {
+        this.logger.error('--> ws: error while disconnecting...');
+        this.logger.error(e);
+        this.logger.error('<-- ws: error caught...');
+      }
+    }
+  }
+
   @UseGuards(SessionAuthGuard)
   async handleConnection(@ConnectedSocket() client: Socket) {
     try {
-      const request = client.request as any;
-      const user = request.user as User;
+      const user = this.getUser(client);
+      this.logger.debug(`client ${user.username} connecting...`);
       const joinedRoom = await this.userService.getJoinedRoom(user);
 
       const roomCode = joinedRoom.room.code;
-      this.logger.debug(`client ${user.username} joining room ${roomCode}`);
-
+      this.logger.log(`client ${user.username} joining room ${roomCode}`);
       client.join(roomCode);
-      this.logger.debug(`client ${client.id} connected`);
+
+      const message: Partial<MessageInterface> = {
+        username: 'system',
+        body: `${user.username}님이 입장하셨습니다.`,
+        timestamp: Date.now(),
+        chatEvent: ChatEvent.Join,
+      };
+      this.server.to(roomCode).emit('chat-message', message);
     } catch (e) {
-      this.logger.error('error while connecting and joining room...');
+      this.logger.error('--> ws: error while connecting and joining room...');
       this.logger.error(e);
+      this.logger.error('<-- ws: error caught...');
     }
   }
 
   @SubscribeMessage('chat-message')
   async handleMessage(
     @ConnectedSocket() client: Socket,
-    @MessageBody() message: Partial<MessageInterface>,
+    @MessageBody() message: MessageInterface,
   ) {
-    const request = client.request as any;
-    const user = request.user as User;
+    const user = this.getUser(client);
     const joinedRoom = await this.userService.getJoinedRoom(user);
     const roomCode = joinedRoom.room.code;
+    this.logger.debug(
+      `--> ws: ${user.username} in room ${roomCode} sent message:`,
+      message,
+    );
 
     if (this.server == null) throw new WsException('server is null');
 
+    this.logger.debug(`--> ws: chat-message ${message.body}`);
     this.server.to(roomCode).emit('chat-message', message);
   }
 
-  handleDisconnect(@ConnectedSocket() client: Socket) {
-    this.logger.debug(`client ${client.id} disconnected`);
+  @SubscribeMessage('game-start')
+  async handleGameStart(@ConnectedSocket() client: Socket) {
+    const user = this.getUser(client);
+    const joinedRoom = await this.userService.getJoinedRoom(user);
+    this.logger.debug(
+      `--> ws: game-start of room ${joinedRoom.room.host} from ${user.username}`,
+    );
+
+    const host = await joinedRoom.room.host;
+    if (host == null) throw new WsException('host is null');
+    if (host.id !== user.id) {
+      throw new WsException('방장이 아닙니다.');
+    }
+
+    const problems = await joinedRoom.room.problems;
+    if (problems == null) throw new WsException('problems is null');
+    if (problems.length === 0) {
+      throw new WsException('문제가 없습니다.');
+    }
+
+    if (this.server == null) throw new WsException('server is null');
+    const roomCode = joinedRoom.room.code;
+
+    const message: GameStartInfo = {
+      problems: problems.map((problem) => problem.bojProblemId.toString()),
+      endTime: joinedRoom.room?.endAt?.toISOString() ?? '',
+    };
+
+    this.logger.debug(`<-- ws: game-start ${message.toString()}`);
+    this.server.to(roomCode).emit('game-start', message);
+  }
+
+  getUser(client: Socket): User {
+    const request = client.request as any;
+    if (request == null) throw new WsException('request is null');
+    const user = request.user;
+    if (user == null) throw new WsException('user is null');
+    return user as User;
+  }
+
+  async submitCode(username: string, roomCode: string, problemId: string) {
+    const message: MessageInterface = {
+      username: 'system',
+      body: `${username}님이 ${problemId} 문제를 제출하셨습니다.`,
+      timestamp: Date.now(),
+      chatEvent: ChatEvent.Submit,
+      color: 'green',
+    };
+    this.server.to(roomCode).emit('chat-message', message);
+  }
+
+  async notifySubmissionStatus(
+    username: string,
+    roomCode: string,
+    problemId: string,
+    status: Status,
+  ) {
+    let message: MessageInterface;
+
+    switch (status) {
+      case Status.ACCEPTED:
+        message = {
+          username: 'system',
+          body: `${username}님이 ${problemId} 문제를 맞았습니다.`,
+          timestamp: Date.now(),
+          chatEvent: ChatEvent.Accepted,
+          color: 'green',
+        };
+        break;
+      case Status.WAITING:
+        throw new WsException('status가 WAITING일 수 없습니다.');
+      case Status.WRONG:
+        message = {
+          username: 'system',
+          body: `${username}님이 ${problemId}를 틀렸습니다.`,
+          timestamp: Date.now(),
+          chatEvent: ChatEvent.Message,
+          color: 'red',
+        };
+        break;
+      default:
+        throw new WsException('status가 알 수 없는 값입니다.');
+    }
+
+    this.server.to(roomCode).emit('chat-message', message);
   }
 }

--- a/server/src/socket/socket.module.ts
+++ b/server/src/socket/socket.module.ts
@@ -5,5 +5,6 @@ import { UserModule } from '../user/user.module';
 @Module({
   providers: [SocketGateway],
   imports: [UserModule],
+  exports: [SocketGateway],
 })
 export class SocketModule {}

--- a/server/src/submission/submission.module.ts
+++ b/server/src/submission/submission.module.ts
@@ -6,6 +6,7 @@ import { RoomUserModule } from 'src/roomUser/room.user.module';
 import { UserModule } from 'src/user/user.module';
 import { SubmissionController } from './submission.controller';
 import { SubmissionService } from './submission.service';
+import { SocketModule } from '../socket/socket.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { SubmissionService } from './submission.service';
     ProblemModule,
     RoomUserModule,
     TypeOrmModule.forFeature([Submission]),
+    SocketModule,
   ],
   controllers: [SubmissionController],
   providers: [SubmissionService],

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -57,7 +57,7 @@ export class UserService {
   async getJoinedRoom(user: User) {
     const joinedRooms = await user.joinedRooms;
     if (joinedRooms == null) {
-      throw new BadRequestException('joinedRooms is null');
+      throw new InternalServerErrorException('joinedRooms is null');
     }
     if (joinedRooms.length !== 1) {
       throw new InternalServerErrorException(


### PR DESCRIPTION
## Submission 서비스에서 웹소켓을 통해 제출 / 현황 알림

1. 제출 알림
2. 제출 결과 알림

위 TODO를 모두 구현했습니다.

## 기타 변경 사항 + 버그 픽스

### feat(Room entity): room에서 user, submissions, problems에 대한 lazy relation 추가

Room 엔티티에 사용자, 제출물, 문제에 대한 지연 로딩 관계(lazy relation)를 추가했습니다.
지연 로딩 관계를 도입했을 때 발생하는 TypeORM의 repository.create 함수 관련 버그에 대해 타협점을 찾았습니다.

### feat(submission entity): room cascade -> false. 제출물이 남아있으면 방이 삭제되지 않도록 변경

제출 엔티티에서 room과의 cascade 관계를 false로 설정하여, 제출물이 남아있는 경우 방이 삭제되지 않도록 변경했습니다.


### 기타 리팩토링

BadRequest와 Forbidden 예외를 에러가 아닌 경고로 처리

모의 인증(mockAuth)에서 내부 서버 오류를 잘못된 요청 오류로 변경

사용자 역직렬화 시 세션 확인 로그를 간소화하여 가독성을 향상

인증 가드에서 로그인 인증 관련 로그의 가독성을 향상

WebSocket 예외 필터에서 로그의 가독성을 향상
