### PR TITLE
hotfix: 스코어보드 시작 버튼 눌러야 보이게

### DIFF
--- a/client/src/components/buttons/ScoreBoardButton.tsx
+++ b/client/src/components/buttons/ScoreBoardButton.tsx
@@ -9,7 +9,7 @@ export default function ScoreboardButton() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [scores , setScores] = useState<Score[]>([]);
   const modalOverlayRef = useRef<HTMLDivElement>(null);
-  const {roomCode} = useRoom();
+  const {roomCode,roomInfo} = useRoom();
 
   const openModal = async () => {
     try {
@@ -33,12 +33,16 @@ export default function ScoreboardButton() {
   };
   return (
     <>
+    {roomInfo.isStarted ? (
       <button
         className="flex w-full flex-row items-center justify-center rounded-lg bg-accent px-3 py-2 text-default_white hover:opacity-80"
         onClick={openModal}>
         <FaChartSimple />
         <div className="pl-2 font-medium">Scoreboard</div>
       </button>
+    ) : (
+      <></>
+    )}
       {isModalOpen ? (
         <ScoreBoardModal
           scores={scores}


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [ ] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description
스코어보드 버튼을 시작을 눌러야 보이게 헀습니다.
roomInfo의 isStarted가 참일 때만 보입니다.

이렇게 하면 roomInfo가 무조건 있는 상태에서만 확인할 수 있어서 404에러가 보이지 않을 것 같습니다.

room-info 소켓 버그 해결 후 테스트 가능합니다.

## Demo
![image](https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/63452858/526d64f1-c861-4bbb-8f2d-6f6d7643a530)
