### PR TITLE
feat/extension-state-management: 익스텐션의 전역 변수 관리

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "images/icon-48.png",
     "128": "images/icon-128.png"
   },
-  "permissions": ["webRequest"],
+  "permissions": ["webRequest", "storage"],
   "host_permissions": ["https://www.acmicpc.net/submit/*", "https://api.baekjoonrooms.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -13,7 +13,7 @@ function injectScript() {
     chrome.runtime.sendMessage({ isActive: true, userInfo });
     isRoom = true;
   } else if (!urlPattern.test(window.location.href) && isRoom) {
-    chrome.runtime.sendMessage({ isActive: false });
+    chrome.runtime.sendMessage({ isActive: false, userInfo: undefined });
     isRoom = false;
   }
 }


### PR DESCRIPTION
## Description

익스텐션의 background.js 에서 전역변수를 사용하였는데, background.js를 돌리는 서비스 워커는 사용되지 않는 상태로  시간이 지나면 비활성화가 됩니다.
비활성화가 된 후 다시 실행이 되면 전역변수가 초기값으로 초기화가 되서 문제가 발생했습니다.
그래서 전역변수를 사용하는 대신 서비스 워커의 로컬스토리지를 이용해 전역변수를 저장해 두어 문제를 해결하였습니다.