### PR TITLE
feat(submission-reject): 방이 시작되지 않았거나, 종료되었거나, 출제되지 않은 문제를 제출하면 거부한다.

### DIFF
--- a/server/src/submission/submission.controller.ts
+++ b/server/src/submission/submission.controller.ts
@@ -22,7 +22,7 @@ export class SubmissionController {
     summary: 'roomCode에 해당하는 방에 속한 유저들의 최종 제출 정보',
   })
   @Get()
-  async getRoomSumbmission(@Query() roomSubmissionDto: RoomSubmissionDto) {
+  async getRoomSubmission(@Query() roomSubmissionDto: RoomSubmissionDto) {
     return await this.submissionService.getRoomSubmission(roomSubmissionDto);
   }
 }


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

## Checklist

- [x] **Code Review:** 작성한 코드를 다시 한 번 꼼꼼이 확인했나요?
- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?
- [x] **Remove:** print나 주석 등 필요없는 코드를 삭제했나요?
- [x] **Rebase:** (필요시) rebase를 완료했나요?
- [x] **Conflict Resolution:** 충돌을 해결하는 과정을 거쳤나요?
- [x] **New Dependencies:** 새로운 dependency를 추가했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Changes Made

- submission.service.ts:

기존에는 유저가 언제 어떤 문제를 제출해도 모두 디비에 반영이 되고 웹소켓을 통해 안내 메세지가 뿌려졌습니다.
이제 다음과 같은 경우 submission이 거절됩니다.

- 방이 시작되지 않았을 때
- 방이 끝났을 때
- 방장이 출제한 문제가 아닐때

## 참고

구현이 간단해서 게임이 끝났을 때 아예 제출을 막는 방식으로 했는데,
빠른 시일 내에 기존 기획대로 게임이 끝나도 문제는 계속 제출할 수 있게 수정할 예정입니다.