### PR TITLE
refactor(*,-tsconfig): baseUrl 제거하고 모듈 임포트 상대 경로로 통일하기

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { UserService } from '../user/user.service';
 import User from '../entities/user.entity';
-import { ProviderInfo } from 'src/types/user';
+import { ProviderInfo } from '../types/user';
 
 @Injectable()
 export class AuthService {

--- a/server/src/entities/room.entity.ts
+++ b/server/src/entities/room.entity.ts
@@ -12,7 +12,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import Problem from './problem.entity';
-import RoomUser from './room-user.entity';
+import RoomUser from '../room-user/room-user.entity';
 import Submission from './submission.entity';
 import User from './user.entity';
 

--- a/server/src/entities/submission.entity.ts
+++ b/server/src/entities/submission.entity.ts
@@ -1,4 +1,4 @@
-import { Status } from 'src/const/boj-results';
+import { Status } from '../const/boj-results';
 import {
   BaseEntity,
   Column,

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -10,7 +10,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import Room from './room.entity';
-import RoomUser from './room-user.entity';
+import RoomUser from '../room-user/room-user.entity';
 import Submission from './submission.entity';
 
 @Entity()

--- a/server/src/problem/problem.module.ts
+++ b/server/src/problem/problem.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import Problem from 'src/entities/problem.entity';
+import Problem from '../entities/problem.entity';
 import { ProblemController } from './problem.controller';
 import { ProblemService } from './problem.service';
 

--- a/server/src/problem/problem.service.ts
+++ b/server/src/problem/problem.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import Problem from 'src/entities/problem.entity';
+import Problem from '../entities/problem.entity';
 import { ILike, In, Raw, Repository } from 'typeorm';
 import { RandomProblemDto } from './dto/random.problem.dto';
 import { SearchProblemDto } from './dto/search.problem.dto';

--- a/server/src/room-user/room-user.entity.ts
+++ b/server/src/room-user/room-user.entity.ts
@@ -8,8 +8,8 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import Room from './room.entity';
-import User from './user.entity';
+import Room from '../entities/room.entity';
+import User from '../entities/user.entity';
 
 @Entity()
 @Index(['room', 'user'], { unique: true })

--- a/server/src/room-user/room-user.module.ts
+++ b/server/src/room-user/room-user.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import RoomUser from 'src/entities/room-user.entity';
+import RoomUser from '../room-user/room-user.entity';
 import { RoomUserService } from './room-user.service';
 
 @Module({

--- a/server/src/room-user/room-user.service.ts
+++ b/server/src/room-user/room-user.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import RoomUser from 'src/entities/room-user.entity';
-import User from 'src/entities/user.entity';
-import { RoomUserInput } from 'src/types/room-user-input';
+import RoomUser from './room-user.entity';
+import User from '../entities/user.entity';
+import { RoomUserInput } from '../types/room-user-input';
 import { Repository } from 'typeorm';
 
 @Injectable()

--- a/server/src/room/room.module.ts
+++ b/server/src/room/room.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import Room from 'src/entities/room.entity';
-import { RoomUserModule } from 'src/room-user/room-user.module';
-import { UserModule } from 'src/user/user.module';
+import Room from '../entities/room.entity';
+import { RoomUserModule } from '../room-user/room-user.module';
+import { UserModule } from '../user/user.module';
 import { RoomController } from './room.controller';
 import { RoomService } from './room.service';
 import { SocketModule } from '../socket/socket.module';

--- a/server/src/room/room.service.ts
+++ b/server/src/room/room.service.ts
@@ -6,12 +6,12 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as crypto from 'crypto';
-import Room from 'src/entities/room.entity';
-import User from 'src/entities/user.entity';
-import { RoomUserService } from 'src/room-user/room-user.service';
-import { UserService } from 'src/user/user.service';
+import Room from '../entities/room.entity';
+import User from '../entities/user.entity';
+import { RoomUserService } from '../room-user/room-user.service';
+import { UserService } from '../user/user.service';
 import { Repository } from 'typeorm';
-import RoomUser from '../entities/room-user.entity';
+import RoomUser from '../room-user/room-user.entity';
 import { SocketService } from '../socket/socket.service';
 
 @Injectable()

--- a/server/src/socket/socket.gateway.ts
+++ b/server/src/socket/socket.gateway.ts
@@ -14,10 +14,10 @@ import { Logger, UseFilters } from '@nestjs/common';
 import { UserService } from '../user/user.service';
 import User from '../entities/user.entity';
 import { WebsocketExceptionsFilter } from './socket.filter';
-import Room from 'src/entities/room.entity';
-import { RoomInfoType } from 'src/types/room-info';
+import Room from '../entities/room.entity';
+import { RoomInfoType } from '../types/room-info';
 import { SocketService } from './socket.service';
-import { ProblemService } from 'src/problem/problem.service';
+import { ProblemService } from '../problem/problem.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -140,6 +140,7 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
     }
   }
+
   getUser(client: Socket): User {
     const request = client.request as any;
     if (request == null) throw new WsException('request is null');

--- a/server/src/socket/socket.module.ts
+++ b/server/src/socket/socket.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { SocketGateway } from './socket.gateway';
 import { UserModule } from '../user/user.module';
 import { SocketService } from './socket.service';
-import { ProblemModule } from 'src/problem/problem.module';
+import { ProblemModule } from '../problem/problem.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import Room from '../entities/room.entity';
 

--- a/server/src/socket/socket.service.ts
+++ b/server/src/socket/socket.service.ts
@@ -5,7 +5,7 @@ import { RoomInfoType } from '../types/room-info';
 import { Server } from 'socket.io';
 import { Status } from '../const/boj-results';
 import { ChatEvent, MessageInterface } from '../types/message-interface';
-import { ProblemType } from 'src/types/problem-type';
+import { ProblemType } from '../types/problem-type';
 import User from '../entities/user.entity';
 import * as util from 'util';
 import { Repository } from 'typeorm';

--- a/server/src/submission/submission.module.ts
+++ b/server/src/submission/submission.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import Submission from 'src/entities/submission.entity';
-import { ProblemModule } from 'src/problem/problem.module';
-import { RoomUserModule } from 'src/room-user/room-user.module';
-import { UserModule } from 'src/user/user.module';
+import Submission from '../entities/submission.entity';
+import { ProblemModule } from '../problem/problem.module';
+import { RoomUserModule } from '../room-user/room-user.module';
+import { UserModule } from '../user/user.module';
 import { SubmissionController } from './submission.controller';
 import { SubmissionService } from './submission.service';
 import { SocketModule } from '../socket/socket.module';
-import { RoomModule } from 'src/room/room.module';
+import { RoomModule } from '../room/room.module';
 
 @Module({
   imports: [

--- a/server/src/submission/submission.service.ts
+++ b/server/src/submission/submission.service.ts
@@ -1,13 +1,13 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as cheerio from 'cheerio';
-import { BojResultsToStatus, Status } from 'src/const/boj-results';
-import Submission from 'src/entities/submission.entity';
-import { ProblemService } from 'src/problem/problem.service';
-import { RoomService } from 'src/room/room.service';
-import { RoomUserService } from 'src/room-user/room-user.service';
-import { BojSubmissionInfo } from 'src/types/submission';
-import { UserService } from 'src/user/user.service';
+import { BojResultsToStatus, Status } from '../const/boj-results';
+import Submission from '../entities/submission.entity';
+import { ProblemService } from '../problem/problem.service';
+import { RoomService } from '../room/room.service';
+import { RoomUserService } from '../room-user/room-user.service';
+import { BojSubmissionInfo } from '../types/submission';
+import { UserService } from '../user/user.service';
 import { Repository } from 'typeorm';
 import { SubmissionDto } from './dto/submission.dto';
 import { SocketService } from '../socket/socket.service';
@@ -15,10 +15,10 @@ import { SocketService } from '../socket/socket.service';
 @Injectable()
 export class SubmissionService {
   private readonly logger = new Logger(SubmissionService.name);
+
   constructor(
     @InjectRepository(Submission)
     private readonly submissionRepository: Repository<Submission>,
-
     private readonly userService: UserService,
     private readonly problemService: ProblemService,
     private readonly roomService: RoomService,

--- a/server/src/types/room-user-input.ts
+++ b/server/src/types/room-user-input.ts
@@ -1,5 +1,5 @@
-import Room from 'src/entities/room.entity';
-import User from 'src/entities/user.entity';
+import Room from '../entities/room.entity';
+import User from '../entities/user.entity';
 
 export interface RoomUserInput {
   room: Room;

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -4,7 +4,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { ProviderInfo } from 'src/types/user';
+import { ProviderInfo } from '../types/user';
 import { Repository } from 'typeorm';
 import User from '../entities/user.entity';
 import { CreateUserDto } from './dto/create.user.dto';

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,


### PR DESCRIPTION
<!-- Review the checklist below before submitting -->

- 본 커밋은 #241 와 연결된 작업입니다.
- 모든 임포트 경로가 "src/ ... " 등의 tsconfig baseUrl 상 절대 경로로 잘못 리펙토링된 점을 수정했습니다.
- tsconfig.json에서 baseUrl을 삭제했습니다.

절대 경로의 문제점: 추가적인 설정 없이는 jest와 같은 외부 툴을 실행하기 어렵습니다.

## Checklist

- [x] **Testing:** 앱이 잘 구동되는지 개발한 기능이 문제 없이 작동하는지 확인했나요?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->
