### PR TITLE
restrict cicd to work only when pull request is merged

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,6 +35,7 @@ jobs:
   cd:
     runs-on: ubuntu-latest
     needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     # ssh to server and run commands
     steps:
       - name: SSH and Deploy


### PR DESCRIPTION
```
 if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

추가를 통해 풀리퀘 어셉될 시에만 cd 실행

![image](https://github.com/boostcampwm2023/web15-BaekjoonRooms/assets/18080546/c903e93b-bf15-4108-8cdd-9c9fe7790917)

스킵이 잘됨