### PR TITLE
feat(user-&-room): seperate api for auth and room

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -18,6 +18,7 @@ import { RoomModule } from './room/room.module';
 import { SocketModule } from './socket/socket.module';
 import { SubmissionModule } from './submission/submission.module';
 import { UserModule } from './user/user.module';
+import { RoomsModule } from './rooms/rooms.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { UserModule } from './user/user.module';
     SubmissionModule,
     RoomUserModule,
     LoggerModule,
+    RoomsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -20,6 +20,15 @@ export class AuthController {
 
   constructor() {}
 
+  @Get('/status')
+  @ApiOperation({
+    summary: 'Check Auth Status',
+    description: 'Check if user is logged in.',
+  })
+  async checkAuthStatus(@Req() req: Request) {
+    return req.isAuthenticated();
+  }
+
   @Get('github')
   @UseGuards(GithubAuthGuard)
   async login() {}

--- a/server/src/entities/room.entity.ts
+++ b/server/src/entities/room.entity.ts
@@ -45,20 +45,17 @@ export default class Room extends BaseEntity {
   @DeleteDateColumn({ type: 'timestamp', nullable: true })
   deletedAt?: Date;
 
-  @ManyToOne(() => User, (user) => user.hostedRooms, {
-    lazy: true,
-    nullable: false,
-  })
-  host?: Promise<User>;
+  @ManyToOne(() => User, (user) => user.hostedRooms)
+  host?: User;
 
-  @OneToMany(() => RoomUser, (roomUser) => roomUser.room, { lazy: true })
-  joinedUsers?: Promise<RoomUser[]>;
+  @OneToMany(() => RoomUser, (roomUser) => roomUser.room)
+  joinedUsers?: RoomUser[];
 
-  @OneToMany(() => Submission, (submission) => submission.room, { lazy: true })
-  submissions?: Promise<Submission[]>;
+  @OneToMany(() => Submission, (submission) => submission.room)
+  submissions?: Submission[];
 
   // 이 방에서 출제된 문제들
-  @ManyToMany(() => Problem, (problem) => problem.rooms, { lazy: true })
+  @ManyToMany(() => Problem, (problem) => problem.rooms)
   @JoinTable()
-  problems?: Promise<Problem[]>;
+  problems?: Problem[];
 }

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -43,7 +43,7 @@ export default class User extends BaseEntity {
   @OneToMany(() => RoomUser, (roomUser) => roomUser.user, {
     lazy: true,
   })
-  joinedRooms?: Promise<RoomUser[]>;
+  joinedRooms?: RoomUser[];
 
   @OneToMany(() => Submission, (submission) => submission.user)
   submissions?: Submission[];

--- a/server/src/room-user/room-user.entity.ts
+++ b/server/src/room-user/room-user.entity.ts
@@ -17,10 +17,10 @@ export default class RoomUser extends BaseEntity {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @ManyToOne(() => Room, (room) => room.joinedUsers, { eager: true })
+  @ManyToOne(() => Room, (room) => room.joinedUsers)
   room!: Room;
 
-  @ManyToOne(() => User, (user) => user.joinedRooms, { eager: true })
+  @ManyToOne(() => User, (user) => user.joinedRooms)
   user!: User;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -10,13 +10,25 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiProperty,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Request } from 'express';
 import { SessionAuthGuard } from '../auth/auth.guard';
 import User from '../entities/user.entity';
 import { RoomUserService } from '../room-user/room-user.service';
 import { RoomCodePipe } from './room-code/room-code.pipe';
 import { RoomService } from './room.service';
+import { IsString } from 'class-validator';
+
+class JoinRoomDto {
+  @ApiProperty()
+  @IsString()
+  code!: string;
+}
 
 @Controller('room')
 @ApiTags('room')
@@ -45,7 +57,10 @@ export class RoomController {
 
   @Post('join')
   @HttpCode(HttpStatus.OK)
-  async joinRoom(@Req() req: Request, @Body() body: { code: string }) {
+  @ApiOperation({
+    summary: '방 참가',
+  })
+  async joinRoom(@Req() req: Request, @Body() body: JoinRoomDto) {
     const user: User = req.user as User;
     const { code } = body;
     this.logger.debug(`user: ${user.username} joining room: ${code}`);

--- a/server/src/room/room.controller.ts
+++ b/server/src/room/room.controller.ts
@@ -39,9 +39,7 @@ export class RoomController {
   })
   async createRoom(@Req() req: Request) {
     const user: User = req.user as User;
-    this.logger.debug(`user ${user.username} creating room...`);
     const room = await this.roomService.createRoom(user);
-    this.logger.debug(`room: ${room.code} successfully created!!`);
     return { code: room.code };
   }
 

--- a/server/src/rooms/rooms.controller.spec.ts
+++ b/server/src/rooms/rooms.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoomsController } from './rooms.controller';
+import { RoomsService } from './rooms.service';
+
+describe('RoomsController', () => {
+  let controller: RoomsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RoomsController],
+      providers: [RoomsService],
+    }).compile();
+
+    controller = module.get<RoomsController>(RoomsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/rooms/rooms.controller.ts
+++ b/server/src/rooms/rooms.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SessionAuthGuard } from '../auth/auth.guard';
+import { RoomsService } from './rooms.service';
+
+@ApiTags('rooms')
+@UseGuards(SessionAuthGuard)
+@Controller('rooms')
+export class RoomsController {
+  constructor(private readonly roomsService: RoomsService) {}
+
+  @Get()
+  findAll() {
+    return this.roomsService.findAll();
+  }
+
+  @Get('/:roomCode/users')
+  findUsers(@Param('roomCode') roomCode: string) {
+    return this.roomsService.findUsers(roomCode);
+  }
+}

--- a/server/src/rooms/rooms.module.ts
+++ b/server/src/rooms/rooms.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RoomsService } from './rooms.service';
+import { RoomsController } from './rooms.controller';
+
+@Module({
+  controllers: [RoomsController],
+  providers: [RoomsService],
+})
+export class RoomsModule {}

--- a/server/src/rooms/rooms.service.spec.ts
+++ b/server/src/rooms/rooms.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoomsService } from './rooms.service';
+
+describe('RoomsService', () => {
+  let service: RoomsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RoomsService],
+    }).compile();
+
+    service = module.get<RoomsService>(RoomsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/rooms/rooms.service.ts
+++ b/server/src/rooms/rooms.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { isNil } from '@nestjs/common/utils/shared.utils';
+import Room from '../entities/room.entity';
+
+@Injectable()
+export class RoomsService {
+  findAll() {
+    return Room.find();
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} room`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} room`;
+  }
+
+  async findUsers(roomCode: string) {
+    const room = await Room.findOne({
+      where: { code: roomCode },
+      relations: ['joinedUsers', 'joinedUsers.user'],
+    });
+
+    if (isNil(room)) {
+      throw new NotFoundException(`Room with code ${roomCode} not found`);
+    }
+
+    const joinedUsers = (await room.joinedUsers) ?? [];
+
+    return { users: joinedUsers.map((joinedUser) => joinedUser.user) };
+  }
+}

--- a/server/src/user/decorators/user.decorator.ts
+++ b/server/src/user/decorators/user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const GetUser = createParamDecorator(
+  (data: string, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const user = request.user;
+    return data ? user?.[data] : user;
+  },
+);

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -1,8 +1,12 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { SessionAuthGuard } from '../auth/auth.guard';
+import User from '../entities/user.entity';
+import { GetUser } from './decorators/user.decorator';
 import { CreateUserDto } from './dto/create.user.dto';
 import { UserService } from './user.service';
 
+@UseGuards(SessionAuthGuard)
 @Controller('users')
 @ApiTags('users')
 export class UserController {
@@ -18,5 +22,21 @@ export class UserController {
   })
   async createUser(@Body() createUserDto: CreateUserDto) {
     return await this.userService.createUser(createUserDto);
+  }
+
+  @Get('/me')
+  @ApiOperation({
+    summary: '내 정보 조회',
+  })
+  async getMyInfo(@GetUser() user: any) {
+    return user;
+  }
+
+  @Get('/me/room-code')
+  @ApiOperation({
+    summary: '내 방 코드 조회',
+  })
+  async getMyRoomCode(@GetUser() user: User) {
+    return this.userService.getRoomIfJoined({ userId: user.id });
   }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SessionAuthGuard } from '../auth/auth.guard';
 import User from '../entities/user.entity';
@@ -6,6 +6,7 @@ import { GetUser } from './decorators/user.decorator';
 import { CreateUserDto } from './dto/create.user.dto';
 import { UserService } from './user.service';
 import Room from '../entities/room.entity';
+import { isNil } from '../common/utils';
 
 @UseGuards(SessionAuthGuard)
 @Controller('users')
@@ -52,18 +53,15 @@ export class UserController {
     });
   }
 
-  @Get('/me/room/:roomCode/am-i-host')
+  @Get('/me/room/am-i-host')
   @ApiOperation({
     summary: '내가 방장인지 조회',
   })
-  async getMyRoomIsHost(
-    @Param('roomCode') roomCode: string,
-    @GetUser() user: User,
-  ) {
+  async getMyRoomIsHost(@GetUser() user: User) {
     const room = await Room.findOne({
-      where: { code: roomCode },
+      where: { host: { id: user.id } },
       relations: ['host'],
     });
-    return { isHost: room?.host?.id === user.id };
+    return !isNil(room);
   }
 }

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -7,6 +7,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { isNil } from 'src/common/utils';
 import { Repository } from 'typeorm';
 import User from '../entities/user.entity';
+import RoomUser from '../room-user/room-user.entity';
 import { ProviderInfo } from '../types/user';
 import { CreateUserDto } from './dto/create.user.dto';
 
@@ -45,6 +46,20 @@ export class UserService {
     return this.userRepository.findOne({
       where: providerInfo,
     });
+  }
+
+  async getRoomIfJoined(param: { userId: number }) {
+    const { userId } = param;
+    const roomUsers = await RoomUser.find({
+      where: { user: { id: userId } },
+      relations: ['user', 'room'],
+    });
+
+    if (roomUsers.length === 0) {
+      throw new BadRequestException('not joined any room');
+    }
+
+    return roomUsers[0].room;
   }
 
   async findJoinedRooms(user: User) {


### PR DESCRIPTION

![image](https://github.com/boostcampwm2023/baekjoonrooms/assets/18080546/997a71dd-2898-42b4-a540-77f09eaa7a7a)

![image](https://github.com/boostcampwm2023/baekjoonrooms/assets/18080546/d43cf1a1-f72f-4396-a88d-1b4c850c65cf)

![image](https://github.com/boostcampwm2023/baekjoonrooms/assets/18080546/684bcc93-f342-4ca3-9bf7-87919f689ab2)



### 모듈 추가 (app.module.ts 변경)

RoomsModule이 추가되었습니다. 이는 기존 RoomModule의 기능의 호환을 깨지 않으면서 점차 더 나은 rest api를 설계하기 위함입니다.

차이점: 기존 api: GET /room/:code/users -> GET /rooms/:code/users  
s가 추가되었습니다.

### 인증 상태 확인 기능 (auth.controller.ts 변경)

/status 엔드포인트를 통해 사용자의 로그인 상태를 확인할 수 있는 기능이 추가되었습니다. 이는 요청 객체에서 인증 여부를 확인하여 반환합니다.

### 엔티티 관계 변경 (room-user.entity.ts 변경)

RoomUser 엔티티에서 Room과 User 엔티티와의 관계에서 eager 로딩 옵션이 제거되었습니다. 이는 관련 데이터를 자동으로 미리 불러오지 않도록 설정한 것입니다.

### 사용자 컨트롤러 추가 기능 (user.controller.ts 변경)

사용자 정보 조회(users/me) 및 사용자가 참여한 방의 코드를 조회(users/me/room-code)하는 두 개의 새로운 엔드포인트가 추가되었습니다.

### 사용자 서비스 로직 추가 (user.service.ts 변경)

사용자가 참여한 방 정보를 조회하는 getRoomIfJoined 메소드가 추가되었습니다. 이 메소드는 사용자 ID를 기반으로 참여한 방을 찾고, 참여한 방이 없으면 예외를 발생시킵니다.